### PR TITLE
Move Cobs Wire Worker behind feature flag.

### DIFF
--- a/example/full-setup/firmware/Cargo.lock
+++ b/example/full-setup/firmware/Cargo.lock
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "postcard-rpc"
-version = "0.2.0"
+version = "0.3.1"
 dependencies = [
  "cobs",
  "defmt",

--- a/example/full-setup/firmware/Cargo.toml
+++ b/example/full-setup/firmware/Cargo.toml
@@ -35,7 +35,7 @@ default-features = false
 
 [dependencies.postcard-rpc]
 path = "../../../source/postcard-rpc"
-features = ["defmt"]
+features = ["defmt", "cobs"]
 
 [dependencies.james-icd]
 path = "../james-icd"

--- a/example/full-setup/host-client/Cargo.lock
+++ b/example/full-setup/host-client/Cargo.lock
@@ -3,27 +3,6 @@
 version = 3
 
 [[package]]
-name = "CoreFoundation-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e9889e6db118d49d88d84728d0e964d973a5680befb5f85f55141beea5c20b"
-dependencies = [
- "libc",
- "mach",
-]
-
-[[package]]
-name = "IOKit-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99696c398cbaf669d2368076bdb3d627fb0ce51a26899d7c61228c5c0af3bf4a"
-dependencies = [
- "CoreFoundation-sys",
- "libc",
- "mach",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,9 +64,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.0.2"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "byteorder"
@@ -153,6 +132,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
 name = "critical-section"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,9 +151,9 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "futures"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -181,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -191,15 +176,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -208,15 +193,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -225,21 +210,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -346,6 +331,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-kit-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4769cb30e5dcf1710fc6730d3e94f78c47723a014a567de385e113c737394640"
+dependencies = [
+ "core-foundation-sys",
+ "mach2",
+]
+
+[[package]]
 name = "james-icd"
 version = "0.1.0"
 dependencies = [
@@ -409,19 +404,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd13ee2dd61cc82833ba05ade5a30bb3d63f7ced605ef827063c63078302de9"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "mach2"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
 ]
@@ -474,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "log",
@@ -622,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "postcard-rpc"
-version = "0.2.0"
+version = "0.3.1"
 dependencies = [
  "cobs",
  "heapless 0.8.0",
@@ -792,18 +778,19 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.2.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32634e2bd4311420caa504404a55fad2131292c485c97014cbed89a5899885f"
+checksum = "8f5a15d0be940df84846264b09b51b10b931fb2f275becb80934e3568a016828"
 dependencies = [
- "CoreFoundation-sys",
- "IOKit-sys",
- "bitflags 2.0.2",
+ "bitflags 2.4.2",
  "cfg-if",
+ "core-foundation-sys",
+ "io-kit-sys",
  "mach2",
  "nix",
  "regex",
  "scopeguard",
+ "unescaper",
  "winapi",
 ]
 
@@ -876,6 +863,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e3de26b0965292219b4287ff031fcba86837900fe9cd2b34ea8ad893c0953d2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "268026685b2be38d7103e9e507c938a1fcb3d7e6eb15e87870b617bf37b6d581"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -988,6 +995,15 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "unescaper"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0adf6ad32eb5b3cadff915f7b770faaac8f7ff0476633aa29eb0d9584d889d34"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]

--- a/example/full-setup/host-client/Cargo.toml
+++ b/example/full-setup/host-client/Cargo.toml
@@ -27,4 +27,4 @@ path = "../james-icd"
 
 [dependencies.postcard-rpc]
 path = "../../../source/postcard-rpc"
-features = ["use-std"]
+features = ["use-std", "cobs-serial"]

--- a/example/full-setup/host-client/src/main.rs
+++ b/example/full-setup/host-client/src/main.rs
@@ -8,7 +8,7 @@ use postcard_rpc::host_client::HostClient;
 
 #[tokio::main]
 async fn main() {
-    let client = HostClient::<FatalError>::new("/dev/tty.usbmodem123456781", ERROR_PATH);
+    let client = HostClient::<FatalError>::new_serial_cobs("/dev/tty.usbmodem123456781", ERROR_PATH, 8, 115_200);
 
     for i in 0..5 {
         tokio::spawn({

--- a/source/postcard-rpc-test/Cargo.lock
+++ b/source/postcard-rpc-test/Cargo.lock
@@ -3,27 +3,6 @@
 version = 3
 
 [[package]]
-name = "CoreFoundation-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e9889e6db118d49d88d84728d0e964d973a5680befb5f85f55141beea5c20b"
-dependencies = [
- "libc",
- "mach",
-]
-
-[[package]]
-name = "IOKit-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99696c398cbaf669d2368076bdb3d627fb0ce51a26899d7c61228c5c0af3bf4a"
-dependencies = [
- "CoreFoundation-sys",
- "libc",
- "mach",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,18 +55,6 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
 
 [[package]]
 name = "byteorder"
@@ -163,95 +130,6 @@ name = "embedded-io"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "futures"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.39",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
-
-[[package]]
-name = "futures-task"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
-
-[[package]]
-name = "futures-util"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
 
 [[package]]
 name = "generator"
@@ -369,24 +247,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd13ee2dd61cc82833ba05ade5a30bb3d63f7ced605ef827063c63078302de9"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "mach2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "maitake-sync"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,15 +275,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,48 +284,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys",
-]
-
-[[package]]
-name = "mio-serial"
-version = "5.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a4c60ca5c9c0e114b3bd66ff4aa5f9b2b175442be51ca6c4365d687a97a2ac"
-dependencies = [
- "log",
- "mio",
- "nix",
- "serialport",
- "winapi",
-]
-
-[[package]]
 name = "mycelium-bitfield"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1178a37e39d26b8c3bbd3197460a59939ca2b8fe002ea92c1d9a1ba87c203d85"
-
-[[package]]
-name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset",
- "pin-utils",
-]
 
 [[package]]
 name = "nu-ansi-term"
@@ -534,12 +347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "portable-atomic"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,13 +381,11 @@ dependencies = [
 name = "postcard-rpc"
 version = "0.3.1"
 dependencies = [
- "cobs",
  "heapless 0.8.0",
  "maitake-sync",
  "postcard",
  "serde",
  "tokio",
- "tokio-serial",
 ]
 
 [[package]]
@@ -715,23 +520,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serialport"
-version = "4.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32634e2bd4311420caa504404a55fad2131292c485c97014cbed89a5899885f"
-dependencies = [
- "CoreFoundation-sys",
- "IOKit-sys",
- "bitflags 2.0.2",
- "cfg-if",
- "mach2",
- "nix",
- "regex",
- "scopeguard",
- "winapi",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,29 +529,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
-
-[[package]]
-name = "socket2"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
-dependencies = [
- "libc",
- "windows-sys",
-]
 
 [[package]]
 name = "spin"
@@ -820,12 +589,8 @@ checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
 dependencies = [
  "backtrace",
  "bytes",
- "libc",
- "mio",
  "pin-project-lite",
- "socket2",
  "tokio-macros",
- "windows-sys",
 ]
 
 [[package]]
@@ -837,19 +602,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.39",
-]
-
-[[package]]
-name = "tokio-serial"
-version = "5.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa6e2e4cf0520a99c5f87d5abb24172b5bd220de57c3181baaaa5440540c64aa"
-dependencies = [
- "cfg-if",
- "futures",
- "log",
- "mio-serial",
- "tokio",
 ]
 
 [[package]]
@@ -932,12 +684,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,15 +710,6 @@ name = "windows"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets",
 ]

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -23,7 +23,7 @@ all-features = true
 rustdoc-args = ["--cfg", "doc_cfg"]
 
 [dependencies]
-cobs = { version = "0.2.3", default-features = false }
+cobs = { version = "0.2.3", optional = true, default-features = false }
 defmt = { version = "0.3.5", optional = true }
 heapless = "0.8.0"
 postcard = { version = "1.0.8", features = ["experimental-derive"] }
@@ -54,7 +54,9 @@ test-utils = [
 use-std = [
     "maitake-sync",
     "tokio",
-    "cobs/use_std",
     "postcard/use-std",
-    "tokio-serial",
+]
+cobs-serial = [
+    "cobs/use_std",
+    "dep:tokio-serial",
 ]

--- a/source/postcard-rpc/src/host_client/mod.rs
+++ b/source/postcard-rpc/src/host_client/mod.rs
@@ -4,7 +4,6 @@
 //! postcard-rpc wire protocol.
 
 use std::{
-    collections::HashMap,
     marker::PhantomData,
     sync::{
         atomic::{AtomicU32, Ordering},
@@ -12,12 +11,12 @@ use std::{
     },
 };
 
+#[cfg(feature = "cobs-serial")]
+mod serial;
+
 use crate::{
-    accumulator::raw::{CobsAccumulator, FeedResult},
-    headered::extract_header_from_bytes,
     Endpoint, Key, Topic, WireHeader,
 };
-use cobs::encode_vec;
 use maitake_sync::{
     wait_map::{WaitError, WakeOutcome},
     WaitMap,
@@ -25,11 +24,9 @@ use maitake_sync::{
 use postcard::experimental::schema::Schema;
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
     select,
     sync::mpsc::{Receiver, Sender},
 };
-use tokio_serial::{SerialPortBuilderExt, SerialStream};
 
 /// Host Error Kind
 #[derive(Debug, PartialEq)]
@@ -54,95 +51,6 @@ impl<T> From<postcard::Error> for HostErr<T> {
 impl<T> From<WaitError> for HostErr<T> {
     fn from(_: WaitError) -> Self {
         Self::Closed
-    }
-}
-
-async fn cobs_wire_worker(mut port: SerialStream, ctx: WireContext) {
-    let mut buf = [0u8; 1024];
-    let mut acc = CobsAccumulator::<1024>::new();
-    let mut subs: HashMap<Key, Sender<RpcFrame>> = HashMap::new();
-
-    let WireContext {
-        mut outgoing,
-        incoming,
-        mut new_subs,
-    } = ctx;
-
-    loop {
-        // Wait for EITHER a serialized request, OR some data from the embedded device
-        select! {
-            sub = new_subs.recv() => {
-                let Some(si) = sub else {
-                    return;
-                };
-
-                subs.insert(si.key, si.tx);
-            }
-            out = outgoing.recv() => {
-                // Receiver returns None when all Senders have hung up
-                let Some(msg) = out else {
-                    return;
-                };
-
-                // Turn the serialized message into a COBS encoded message
-                //
-                // TODO: this is a little wasteful, payload is already a vec,
-                // then we serialize it to a second vec, then encode that to
-                // a third cobs-encoded vec. Oh well.
-                let msg = msg.to_bytes();
-                let mut msg = encode_vec(&msg);
-                msg.push(0);
-
-                // And send it!
-                if port.write_all(&msg).await.is_err() {
-                    // I guess the serial port hung up.
-                    return;
-                }
-            }
-            inc = port.read(&mut buf) => {
-                // if read errored, we're done
-                let Ok(used) = inc else {
-                    return;
-                };
-                let mut window = &buf[..used];
-
-                'cobs: while !window.is_empty() {
-                    window = match acc.feed(window) {
-                        // Consumed the whole USB frame
-                        FeedResult::Consumed => break 'cobs,
-                        // Silently ignore line errors
-                        // TODO: probably add tracing here
-                        FeedResult::OverFull(new_wind) => new_wind,
-                        FeedResult::DeserError(new_wind) => new_wind,
-                        // We got a message! Attempt to dispatch it
-                        FeedResult::Success { data, remaining } => {
-                            // Attempt to extract a header so we can get the sequence number
-                            if let Ok((hdr, body)) = extract_header_from_bytes(data) {
-                                // Got a header, turn it into a frame
-                                let frame = RpcFrame { header: hdr.clone(), body: body.to_vec() };
-
-                                // Give priority to subscriptions. TBH I only do this because I know a hashmap
-                                // lookup is cheaper than a waitmap search.
-                                if let Some(tx) = subs.get_mut(&hdr.key) {
-                                    // Yup, we have a subscription
-                                    if tx.send(frame).await.is_err() {
-                                        // But if sending failed, the listener is gone, so drop it
-                                        subs.remove(&hdr.key);
-                                    }
-                                } else {
-                                    // Wake the given sequence number. If the WaitMap is closed, we're done here
-                                    if let Err(ProcessError::Closed) = incoming.process(frame) {
-                                        return;
-                                    }
-                                }
-                            }
-
-                            remaining
-                        }
-                    };
-                }
-            }
-        }
     }
 }
 
@@ -200,66 +108,6 @@ where
         };
 
         (me, wire)
-    }
-
-    /// Create a new [HostClient]
-    ///
-    /// `serial_path` is the path to the serial port used. `err_uri_path` is
-    /// the path associated with the `WireErr` message type.
-    ///
-    /// Panics if we couldn't open the serial port
-    ///
-    /// ## Example
-    ///
-    /// ```rust,no_run
-    /// use postcard_rpc::host_client::HostClient;
-    /// use serde::{Serialize, Deserialize};
-    /// use postcard::experimental::schema::Schema;
-    ///
-    /// /// A "wire error" type your server can use to respond to any
-    /// /// kind of request, for example if deserializing a request fails
-    /// #[derive(Debug, PartialEq, Schema, Serialize, Deserialize)]
-    /// pub enum Error {
-    ///    SomethingBad
-    /// }
-    ///
-    /// let client = HostClient::<Error>::new_serial_cobs(
-    ///     // the serial port path
-    ///     "/dev/ttyACM0",
-    ///     // the URI/path for `Error` messages
-    ///     "error",
-    ///     // Outgoing queue depth in messages
-    ///     8,
-    ///     // Baud rate of serial (does not generally matter for
-    ///     //  USB UART/CDC-ACM serial connections)
-    ///     115_200,
-    /// );
-    /// ```
-    ///
-    pub fn new_serial_cobs(
-        serial_path: &str,
-        err_uri_path: &str,
-        outgoing_depth: usize,
-        baud: u32,
-    ) -> Self {
-        let (me, wire) = Self::new_manual(err_uri_path, outgoing_depth);
-
-        let port = tokio_serial::new(serial_path, baud)
-            .open_native_async()
-            .unwrap();
-
-        tokio::task::spawn(async move { cobs_wire_worker(port, wire).await });
-
-        me
-    }
-
-    /// Create a new instance
-    ///
-    /// Same as [HostClient::new_serial_cobs] with baudrate of 115_200 and
-    /// outgoing depth of 8.
-    #[deprecated = "use `Self::new_serial_cobs`"]
-    pub fn new(serial_path: &str, err_uri_path: &str) -> Self {
-        Self::new_serial_cobs(serial_path, err_uri_path, 8, 115_200)
     }
 }
 

--- a/source/postcard-rpc/src/host_client/serial.rs
+++ b/source/postcard-rpc/src/host_client/serial.rs
@@ -111,6 +111,8 @@ where
     ///
     /// Panics if we couldn't open the serial port
     ///
+    /// This constructor is available when the `cobs-serial` feature is enabled.
+    ///
     /// ## Example
     ///
     /// ```rust,no_run

--- a/source/postcard-rpc/src/host_client/serial.rs
+++ b/source/postcard-rpc/src/host_client/serial.rs
@@ -1,0 +1,157 @@
+
+use crate::{accumulator::raw::{CobsAccumulator, FeedResult}, headered::extract_header_from_bytes, Key};
+use postcard::experimental::schema::Schema;
+use serde::de::DeserializeOwned;
+use tokio_serial::{SerialPortBuilderExt, SerialStream};
+use tokio::{io::{AsyncReadExt, AsyncWriteExt}, select, sync::mpsc::Sender};
+use cobs::encode_vec;
+use std::collections::HashMap;
+use super::{HostClient, RpcFrame, WireContext, ProcessError};
+
+async fn cobs_wire_worker(mut port: SerialStream, ctx: WireContext) {
+    let mut buf = [0u8; 1024];
+    let mut acc = CobsAccumulator::<1024>::new();
+    let mut subs: HashMap<Key, Sender<RpcFrame>> = HashMap::new();
+
+    let WireContext {
+        mut outgoing,
+        incoming,
+        mut new_subs,
+    } = ctx;
+
+    loop {
+        // Wait for EITHER a serialized request, OR some data from the embedded device
+        select! {
+            sub = new_subs.recv() => {
+                let Some(si) = sub else {
+                    return;
+                };
+
+                subs.insert(si.key, si.tx);
+            }
+            out = outgoing.recv() => {
+                // Receiver returns None when all Senders have hung up
+                let Some(msg) = out else {
+                    return;
+                };
+
+                // Turn the serialized message into a COBS encoded message
+                //
+                // TODO: this is a little wasteful, payload is already a vec,
+                // then we serialize it to a second vec, then encode that to
+                // a third cobs-encoded vec. Oh well.
+                let msg = msg.to_bytes();
+                let mut msg = encode_vec(&msg);
+                msg.push(0);
+
+                // And send it!
+                if port.write_all(&msg).await.is_err() {
+                    // I guess the serial port hung up.
+                    return;
+                }
+            }
+            inc = port.read(&mut buf) => {
+                // if read errored, we're done
+                let Ok(used) = inc else {
+                    return;
+                };
+                let mut window = &buf[..used];
+
+                'cobs: while !window.is_empty() {
+                    window = match acc.feed(window) {
+                        // Consumed the whole USB frame
+                        FeedResult::Consumed => break 'cobs,
+                        // Silently ignore line errors
+                        // TODO: probably add tracing here
+                        FeedResult::OverFull(new_wind) => new_wind,
+                        FeedResult::DeserError(new_wind) => new_wind,
+                        // We got a message! Attempt to dispatch it
+                        FeedResult::Success { data, remaining } => {
+                            // Attempt to extract a header so we can get the sequence number
+                            if let Ok((hdr, body)) = extract_header_from_bytes(data) {
+                                // Got a header, turn it into a frame
+                                let frame = RpcFrame { header: hdr.clone(), body: body.to_vec() };
+
+                                // Give priority to subscriptions. TBH I only do this because I know a hashmap
+                                // lookup is cheaper than a waitmap search.
+                                if let Some(tx) = subs.get_mut(&hdr.key) {
+                                    // Yup, we have a subscription
+                                    if tx.send(frame).await.is_err() {
+                                        // But if sending failed, the listener is gone, so drop it
+                                        subs.remove(&hdr.key);
+                                    }
+                                } else {
+                                    // Wake the given sequence number. If the WaitMap is closed, we're done here
+                                    if let Err(ProcessError::Closed) = incoming.process(frame) {
+                                        return;
+                                    }
+                                }
+                            }
+
+                            remaining
+                        }
+                    };
+                }
+            }
+        }
+    }
+}
+
+/// # Constructor Methods
+///
+/// These methods are used to create a new [HostClient] instance for use with tokio serial and cobs encoding.
+impl<WireErr> HostClient<WireErr>
+where
+    WireErr: DeserializeOwned + Schema,
+{
+    /// Create a new [HostClient]
+    ///
+    /// `serial_path` is the path to the serial port used. `err_uri_path` is
+    /// the path associated with the `WireErr` message type.
+    ///
+    /// Panics if we couldn't open the serial port
+    ///
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// use postcard_rpc::host_client::HostClient;
+    /// use serde::{Serialize, Deserialize};
+    /// use postcard::experimental::schema::Schema;
+    ///
+    /// /// A "wire error" type your server can use to respond to any
+    /// /// kind of request, for example if deserializing a request fails
+    /// #[derive(Debug, PartialEq, Schema, Serialize, Deserialize)]
+    /// pub enum Error {
+    ///    SomethingBad
+    /// }
+    ///
+    /// let client = HostClient::<Error>::new_serial_cobs(
+    ///     // the serial port path
+    ///     "/dev/ttyACM0",
+    ///     // the URI/path for `Error` messages
+    ///     "error",
+    ///     // Outgoing queue depth in messages
+    ///     8,
+    ///     // Baud rate of serial (does not generally matter for
+    ///     //  USB UART/CDC-ACM serial connections)
+    ///     115_200,
+    /// );
+    /// ```
+    ///
+    pub fn new_serial_cobs(
+        serial_path: &str,
+        err_uri_path: &str,
+        outgoing_depth: usize,
+        baud: u32,
+    ) -> Self {
+        let (me, wire) = Self::new_manual(err_uri_path, outgoing_depth);
+
+        let port = tokio_serial::new(serial_path, baud)
+            .open_native_async()
+            .unwrap();
+
+        tokio::task::spawn(async move { cobs_wire_worker(port, wire).await });
+
+        me
+    }
+}

--- a/source/postcard-rpc/src/lib.rs
+++ b/source/postcard-rpc/src/lib.rs
@@ -175,7 +175,9 @@ use headered::extract_header_from_bytes;
 use postcard::experimental::schema::Schema;
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "cobs")]
 pub mod accumulator;
+
 pub mod hash;
 pub mod headered;
 

--- a/source/postcard-rpc/src/lib.rs
+++ b/source/postcard-rpc/src/lib.rs
@@ -166,6 +166,9 @@
 //! particularly the [`HostClient`][host_client::HostClient] struct.
 //! This is only available with the `use-std` feature active.
 //!
+//! A serial-port transport using cobs encoding is available with the `cobs-serial` feature.
+//! This feature will add the [`new_serial_cobs`][host_client::HostClient::new_serial_cobs] constructor to [`HostClient`][host_client::HostClient].
+//!
 //! For Server facilities, check out the [`Dispatch`] struct. This is
 //! available with or without the standard library.
 
@@ -222,6 +225,7 @@ impl<E> From<postcard::Error> for Error<E> {
 /// which will automatically handle accumulating bytes from the wire.
 ///
 /// [CobsDispatch]: crate::accumulator::dispatch::CobsDispatch
+/// Note: This will be available when the `cobs` or `cobs-serial` feature is enabled.
 pub struct Dispatch<Context, Error, const N: usize> {
     items: heapless::Vec<(Key, Handler<Context, Error>), N>,
     context: Context,


### PR DESCRIPTION
Hi, I tried to use Postcard-RPC in a project. I think it's actually pretty nice to use, but I have no need for the serial COBS worker or the Tokio serial dependency. I moved the Tokio serial stuff to a new mod and put that behind a feature flag.

Do you think this is a good idea, or would you solve this in a different way?

P.S. I did remove the deprecated new constructor.