### PR TITLE
Add support for retrying `send_resp`.

### DIFF
--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -47,7 +47,7 @@ features = ["sync", "rt", "macros", "io-util"]
 optional = true
 
 [features]
-default = []
+default = ["cobs-serial", "test-utils"]
 test-utils = [
     "use-std",
 ]


### PR DESCRIPTION
This adds the ability to retry an RPC and still be able to uniquely identify from which sequence number the original command came.

Feedback welcome!