### PR TITLE
Remove direct `embassy-usb-driver` dependency

### DIFF
--- a/example/firmware/Cargo.lock
+++ b/example/firmware/Cargo.lock
@@ -1128,7 +1128,6 @@ dependencies = [
  "embassy-executor",
  "embassy-sync",
  "embassy-usb",
- "embassy-usb-driver",
  "heapless 0.8.0",
  "postcard",
  "serde",

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -62,9 +62,6 @@ optional = true
 version = "0.2"
 optional = true
 
-[dependencies.embassy-usb-driver]
-version = "0.1"
-optional = true
 
 [dependencies.embassy-sync]
 version = "0.5"
@@ -111,7 +108,6 @@ embassy-usb-0_2-server = [
     "dep:embassy-usb",
     "dep:embassy-sync",
     "dep:static_cell",
-    "dep:embassy-usb-driver",
     "dep:embassy-executor",
 ]
 

--- a/source/postcard-rpc/src/lib.rs
+++ b/source/postcard-rpc/src/lib.rs
@@ -173,6 +173,7 @@
 //! available with or without the standard library.
 
 #![cfg_attr(not(any(test, feature = "use-std")), no_std)]
+#![feature(impl_trait_in_assoc_type)]
 
 use headered::extract_header_from_bytes;
 use postcard::experimental::schema::Schema;

--- a/source/postcard-rpc/src/target_server/dispatch_macro.rs
+++ b/source/postcard-rpc/src/target_server/dispatch_macro.rs
@@ -4,7 +4,7 @@
 /// # use postcard_rpc::target_server::dispatch_macro::fake::*;
 /// # use postcard_rpc::{endpoint, target_server::{sender::Sender, SpawnContext}, WireHeader, define_dispatch};
 /// # use postcard::experimental::schema::Schema;
-/// # use embassy_usb_driver::{Bus, ControlPipe, EndpointIn, EndpointOut};
+/// # use embassy_usb::driver::{Bus, ControlPipe, EndpointIn, EndpointOut};
 /// # use serde::{Deserialize, Serialize};
 ///
 /// pub struct DispatchCtx;
@@ -199,7 +199,7 @@ pub mod fake {
     use crate::target_server::SpawnContext;
     #[allow(unused_imports)]
     use crate::{endpoint, target_server::sender::Sender, Schema, WireHeader};
-    use embassy_usb_driver::{Bus, ControlPipe, EndpointIn, EndpointOut};
+    use embassy_usb::driver::{Bus, ControlPipe, EndpointIn, EndpointOut};
     use serde::{Deserialize, Serialize};
 
     #[derive(Serialize, Deserialize, Schema)]
@@ -236,8 +236,8 @@ pub mod fake {
     pub struct FakeCtlPipe;
     pub struct FakeBus;
 
-    impl embassy_usb_driver::Endpoint for FakeEpOut {
-        fn info(&self) -> &embassy_usb_driver::EndpointInfo {
+    impl embassy_usb::driver::Endpoint for FakeEpOut {
+        fn info(&self) -> &embassy_usb::driver::EndpointInfo {
             todo!()
         }
 
@@ -250,13 +250,13 @@ pub mod fake {
         async fn read(
             &mut self,
             _buf: &mut [u8],
-        ) -> Result<usize, embassy_usb_driver::EndpointError> {
+        ) -> Result<usize, embassy_usb::driver::EndpointError> {
             todo!()
         }
     }
 
-    impl embassy_usb_driver::Endpoint for FakeEpIn {
-        fn info(&self) -> &embassy_usb_driver::EndpointInfo {
+    impl embassy_usb::driver::Endpoint for FakeEpIn {
+        fn info(&self) -> &embassy_usb::driver::EndpointInfo {
             todo!()
         }
 
@@ -266,7 +266,7 @@ pub mod fake {
     }
 
     impl EndpointIn for FakeEpIn {
-        async fn write(&mut self, _buf: &[u8]) -> Result<(), embassy_usb_driver::EndpointError> {
+        async fn write(&mut self, _buf: &[u8]) -> Result<(), embassy_usb::driver::EndpointError> {
             todo!()
         }
     }
@@ -285,7 +285,7 @@ pub mod fake {
             _buf: &mut [u8],
             _first: bool,
             _last: bool,
-        ) -> Result<usize, embassy_usb_driver::EndpointError> {
+        ) -> Result<usize, embassy_usb::driver::EndpointError> {
             todo!()
         }
 
@@ -294,7 +294,7 @@ pub mod fake {
             _data: &[u8],
             _first: bool,
             _last: bool,
-        ) -> Result<(), embassy_usb_driver::EndpointError> {
+        ) -> Result<(), embassy_usb::driver::EndpointError> {
             todo!()
         }
 
@@ -320,13 +320,13 @@ pub mod fake {
             todo!()
         }
 
-        async fn poll(&mut self) -> embassy_usb_driver::Event {
+        async fn poll(&mut self) -> embassy_usb::driver::Event {
             todo!()
         }
 
         fn endpoint_set_enabled(
             &mut self,
-            _ep_addr: embassy_usb_driver::EndpointAddress,
+            _ep_addr: embassy_usb::driver::EndpointAddress,
             _enabled: bool,
         ) {
             todo!()
@@ -334,22 +334,22 @@ pub mod fake {
 
         fn endpoint_set_stalled(
             &mut self,
-            _ep_addr: embassy_usb_driver::EndpointAddress,
+            _ep_addr: embassy_usb::driver::EndpointAddress,
             _stalled: bool,
         ) {
             todo!()
         }
 
-        fn endpoint_is_stalled(&mut self, _ep_addr: embassy_usb_driver::EndpointAddress) -> bool {
+        fn endpoint_is_stalled(&mut self, _ep_addr: embassy_usb::driver::EndpointAddress) -> bool {
             todo!()
         }
 
-        async fn remote_wakeup(&mut self) -> Result<(), embassy_usb_driver::Unsupported> {
+        async fn remote_wakeup(&mut self) -> Result<(), embassy_usb::driver::Unsupported> {
             todo!()
         }
     }
 
-    impl embassy_usb_driver::Driver<'static> for FakeDriver {
+    impl embassy_usb::driver::Driver<'static> for FakeDriver {
         type EndpointOut = FakeEpOut;
 
         type EndpointIn = FakeEpIn;
@@ -360,19 +360,19 @@ pub mod fake {
 
         fn alloc_endpoint_out(
             &mut self,
-            _ep_type: embassy_usb_driver::EndpointType,
+            _ep_type: embassy_usb::driver::EndpointType,
             _max_packet_size: u16,
             _interval_ms: u8,
-        ) -> Result<Self::EndpointOut, embassy_usb_driver::EndpointAllocError> {
+        ) -> Result<Self::EndpointOut, embassy_usb::driver::EndpointAllocError> {
             todo!()
         }
 
         fn alloc_endpoint_in(
             &mut self,
-            _ep_type: embassy_usb_driver::EndpointType,
+            _ep_type: embassy_usb::driver::EndpointType,
             _max_packet_size: u16,
             _interval_ms: u8,
-        ) -> Result<Self::EndpointIn, embassy_usb_driver::EndpointAllocError> {
+        ) -> Result<Self::EndpointIn, embassy_usb::driver::EndpointAllocError> {
             todo!()
         }
 

--- a/source/postcard-rpc/src/target_server/mod.rs
+++ b/source/postcard-rpc/src/target_server/mod.rs
@@ -7,11 +7,10 @@ use crate::{
 };
 use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_usb::{
-    driver::Driver,
+    driver::{Driver, Endpoint, EndpointError, EndpointOut},
     msos::{self, windows_version},
     Builder, UsbDevice,
 };
-use embassy_usb_driver::{Endpoint, EndpointError, EndpointOut};
 use sender::Sender;
 
 pub mod buffers;

--- a/source/postcard-rpc/src/target_server/sender.rs
+++ b/source/postcard-rpc/src/target_server/sender.rs
@@ -1,5 +1,5 @@
 use embassy_sync::{blocking_mutex::raw::RawMutex, mutex::Mutex};
-use embassy_usb_driver::{Driver, Endpoint, EndpointIn};
+use embassy_usb::driver::{Driver, Endpoint, EndpointIn};
 use postcard::experimental::schema::Schema;
 use serde::Serialize;
 use static_cell::StaticCell;


### PR DESCRIPTION
This removes the direct dependency on `embassy-usb-driver` and instead uses the re-exported version from `embassy-usb`. Without these changes I wasn't able to get `postcard-rpc` to compile in my project with the following errors:

<details>
  <summary>Errors</summary>

```
error[E0658]: `impl Trait` in associated types is unstable
   --> /home/alexander/Documents/dev/postcard-rpc/source/postcard-rpc/src/target_server/dispatch_macro.rs:446:5
    |
446 |     #[embassy_executor::task]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
    = note: this compiler was built on 2024-04-21; consider upgrading it if it is out of date
    = note: this error originates in the attribute macro `embassy_executor::task` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no method named `wait_enabled` found for associated type `<D as embassy_usb::embassy_usb_driver::Driver<'static>>::EndpointOut` in the current scope
   --> /home/alexander/Documents/dev/postcard-rpc/source/postcard-rpc/src/target_server/mod.rs:130:16
    |
130 |         ep_out.wait_enabled().await;
    |                ^^^^^^^^^^^^ method not found in `<D as Driver<'static>>::EndpointOut`
    |
   ::: /home/alexander/.cargo/git/checkouts/embassy-9312dcb0ed774b29/e3e3728/embassy-usb-driver/src/lib.rs:227:14
    |
227 |     async fn wait_enabled(&mut self);
    |              ------------ the method is available for `<D as embassy_usb::embassy_usb_driver::Driver<'static>>::EndpointOut` here
    |
    = help: items from traits can only be used if the trait is in scope
help: trait `Endpoint` which provides `wait_enabled` is implemented but not in scope; perhaps you want to import it
    |
3   + use embassy_usb::embassy_usb_driver::Endpoint;
    |

error[E0599]: no method named `read` found for associated type `<D as embassy_usb::embassy_usb_driver::Driver<'static>>::EndpointOut` in the current scope
   --> /home/alexander/Documents/dev/postcard-rpc/source/postcard-rpc/src/target_server/mod.rs:143:38
    |
143 |                         match ep_out.read(rx_buf).await {
    |                                      ^^^^ method not found in `<D as Driver<'static>>::EndpointOut`
    |
   ::: /home/alexander/.cargo/git/checkouts/embassy-9312dcb0ed774b29/e3e3728/embassy-usb-driver/src/lib.rs:236:14
    |
236 |     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, EndpointError>;
    |              ---- the method is available for `<D as embassy_usb::embassy_usb_driver::Driver<'static>>::EndpointOut` here
    |
    = help: items from traits can only be used if the trait is in scope
help: trait `EndpointOut` which provides `read` is implemented but not in scope; perhaps you want to import it
    |
3   + use embassy_usb::embassy_usb_driver::EndpointOut;
    |

error[E0599]: no method named `read` found for associated type `<D as embassy_usb::embassy_usb_driver::Driver<'static>>::EndpointOut` in the current scope
   --> /home/alexander/Documents/dev/postcard-rpc/source/postcard-rpc/src/target_server/mod.rs:163:38
    |
163 |                 let n = match ep_out.read(window).await {
    |                                      ^^^^ method not found in `<D as Driver<'static>>::EndpointOut`
    |
   ::: /home/alexander/.cargo/git/checkouts/embassy-9312dcb0ed774b29/e3e3728/embassy-usb-driver/src/lib.rs:236:14
    |
236 |     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, EndpointError>;
    |              ---- the method is available for `<D as embassy_usb::embassy_usb_driver::Driver<'static>>::EndpointOut` here
    |
    = help: items from traits can only be used if the trait is in scope
help: trait `EndpointOut` which provides `read` is implemented but not in scope; perhaps you want to import it
    |
3   + use embassy_usb::embassy_usb_driver::EndpointOut;
    |

error[E0277]: the trait bound `<Self as target_server::Dispatch>::Driver: embassy_usb_driver::Driver<'static>` is not satisfied
  --> /home/alexander/Documents/dev/postcard-rpc/source/postcard-rpc/src/target_server/mod.rs:43:25
   |
43 |     fn sender(&self) -> Sender<Self::Mutex, Self::Driver>;
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `embassy_usb_driver::Driver<'static>` is not implemented for `<Self as target_server::Dispatch>::Driver`
   |
note: required by a bound in `sender::Sender`
  --> /home/alexander/Documents/dev/postcard-rpc/source/postcard-rpc/src/target_server/sender.rs:15:45
   |
15 | pub struct Sender<M: RawMutex + 'static, D: Driver<'static> + 'static> {
   |                                             ^^^^^^^^^^^^^^^ required by this bound in `Sender`
help: consider further restricting the associated type
   |
43 |     fn sender(&self) -> Sender<Self::Mutex, Self::Driver> where <Self as target_server::Dispatch>::Driver: embassy_usb_driver::Driver<'static>;
   |                                                           ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

error[E0277]: the trait bound `FakeDriver: embassy_usb::embassy_usb_driver::Driver<'static>` is not satisfied
   --> /home/alexander/Documents/dev/postcard-rpc/source/postcard-rpc/src/target_server/dispatch_macro.rs:410:64
    |
410 |         dispatcher: TestDispatcher<Mutex = FakeMutex, Driver = FakeDriver, Context = TestContext>;
    |                                                                ^^^^^^^^^^ the trait `embassy_usb::embassy_usb_driver::Driver<'static>` is not implemented for `FakeDriver`
    |
note: required by a bound in `target_server::Dispatch::Driver`
   --> /home/alexander/Documents/dev/postcard-rpc/source/postcard-rpc/src/target_server/mod.rs:29:18
    |
29  |     type Driver: Driver<'static>;
    |                  ^^^^^^^^^^^^^^^ required by this bound in `Dispatch::Driver`

error[E0277]: the trait bound `FakeDriver: embassy_usb::embassy_usb_driver::Driver<'static>` is not satisfied
   --> /home/alexander/Documents/dev/postcard-rpc/source/postcard-rpc/src/target_server/dispatch_macro.rs:118:24
    |
118 |                   ep_in: <$driver as ::embassy_usb::driver::Driver<'static>>::EndpointIn,
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `embassy_usb::embassy_usb_driver::Driver<'static>` is not implemented for `FakeDriver`
...
409 | /     define_dispatch! {
410 | |         dispatcher: TestDispatcher<Mutex = FakeMutex, Driver = FakeDriver, Context = TestContext>;
411 | |         AlphaEndpoint => async test_alpha_handler,
412 | |         BetaEndpoint => async test_beta_handler,
...   |
415 | |         EpsilonEndpoint => spawn test_epsilon_handler_task,
416 | |     }
    | |_____- in this macro invocation
    |
    = note: this error originates in the macro `define_dispatch` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `FakeDriver: embassy_usb::embassy_usb_driver::Driver<'static>` is not satisfied
   --> /home/alexander/Documents/dev/postcard-rpc/source/postcard-rpc/src/target_server/dispatch_macro.rs:120:23
    |
120 |               ) -> Self {
    |  _______________________^
121 | |                 static SENDER_INNER: ::static_cell::StaticCell<
122 | |                     ::embassy_sync::mutex::Mutex<$mutex, $crate::target_server::sender::SenderInner<$driver>>,
123 | |                 > = ::static_cell::StaticCell::new();
...   |
127 | |                 }
128 | |             }
    | |_____________^ the trait `embassy_usb::embassy_usb_driver::Driver<'static>` is not implemented for `FakeDriver`
...
409 | /     define_dispatch! {
410 | |         dispatcher: TestDispatcher<Mutex = FakeMutex, Driver = FakeDriver, Context = TestContext>;
411 | |         AlphaEndpoint => async test_alpha_handler,
412 | |         BetaEndpoint => async test_beta_handler,
...   |
415 | |         EpsilonEndpoint => spawn test_epsilon_handler_task,
416 | |     }
    | |_____- in this macro invocation
    |
    = note: this error originates in the macro `define_dispatch` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unused import: `EndpointOut`
  --> /home/alexander/Documents/dev/postcard-rpc/source/postcard-rpc/src/target_server/mod.rs:14:51
   |
14 | use embassy_usb_driver::{Endpoint, EndpointError, EndpointOut};
   |                                                   ^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `Endpoint`
  --> /home/alexander/Documents/dev/postcard-rpc/source/postcard-rpc/src/target_server/mod.rs:14:26
   |
14 | use embassy_usb_driver::{Endpoint, EndpointError, EndpointOut};
   |                          ^^^^^^^^

Some errors have detailed explanations: E0277, E0599, E0658.
For more information about an error, try `rustc --explain E0277`.
warning: `postcard-rpc` (lib) generated 2 warnings
error: could not compile `postcard-rpc` (lib) due to 8 previous errors; 2 warnings emitted
warning: build failed, waiting for other jobs to finish...
```
</details>

I don't fully understand what the problem is but I figure this change is mostly harmless.

I also added the `#![feature(impl_trait_in_assoc_type)]` crate attribute to silence the error from the `fake` module. I'm not sure why I need this because I already have this attribute in my own crate root. It also makes this crate nightly-only which is probably not what you want. Alternatively the whole module could be guarded behind a feature flag.