### PR TITLE
Remove embassy-executor-nightly feature

### DIFF
--- a/example/firmware/Cargo.toml
+++ b/example/firmware/Cargo.toml
@@ -5,8 +5,6 @@ edition = "2021"
 
 [dependencies]
 cortex-m                = { version = "0.7.6", features = ["inline-asm"] }
-# NOTE: if you need the `nightly` feature of `embassy-executor`, you MUST also activate
-# the `embassy-executor-nightly` feature of `postcard-rpc`!
 embassy-executor        = { version = "0.5.0", features = ["task-arena-size-32768", "arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
 embassy-rp              = { version = "0.1.0", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl"] }
 embassy-sync            = { version = "0.5.0", features = ["defmt"] }

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -85,6 +85,9 @@ optional = true
 version = "0.5"
 optional = true
 
+[dev-dependencies]
+postcard-rpc = { path = "../postcard-rpc", features = ["test-utils"] }
+
 #
 # Hack features (see below)
 #
@@ -118,12 +121,6 @@ embassy-usb-0_2-server = [
     "dep:static_cell",
     "dep:embassy-usb-driver",
     "dep:embassy-executor",
-]
-
-# NOTE: if you use the nightly feature of embassy-executor, you must
-# also activate this feature!
-embassy-executor-nightly = [
-    "embassy-executor/nightly"
 ]
 
 # NOTE: This exists because `embassy-usb` indirectly relies on ssmarshal

--- a/source/postcard-rpc/src/lib.rs
+++ b/source/postcard-rpc/src/lib.rs
@@ -173,9 +173,6 @@
 //! available with or without the standard library.
 
 #![cfg_attr(not(any(test, feature = "use-std")), no_std)]
-// If you use the nightly feature from embassy-executor, we need to activate this feature
-// as our docs/tests will also end up using that feature too.
-#![cfg_attr(feature = "embassy-executor-nightly", feature(type_alias_impl_trait))]
 
 use headered::extract_header_from_bytes;
 use postcard::experimental::schema::Schema;

--- a/source/postcard-rpc/src/target_server/dispatch_macro.rs
+++ b/source/postcard-rpc/src/target_server/dispatch_macro.rs
@@ -1,10 +1,6 @@
 /// # Define Dispatch Macro
 ///
 /// ```rust
-/// # // If you use the nightly feature from embassy-executor, we need to activate this feature
-/// # // as our docs/tests will also end up using that feature too.
-/// # #![cfg_attr(feature = "embassy-executor-nightly", feature(type_alias_impl_trait))]
-///
 /// # use postcard_rpc::target_server::dispatch_macro::fake::*;
 /// # use postcard_rpc::{endpoint, target_server::{sender::Sender, SpawnContext}, WireHeader, define_dispatch};
 /// # use postcard::experimental::schema::Schema;
@@ -199,6 +195,7 @@ macro_rules! define_dispatch {
 /// as well as provide impls for docs. Don't rely on any of this!
 #[doc(hidden)]
 #[allow(dead_code)]
+#[cfg(feature = "test-utils")]
 pub mod fake {
     use crate::target_server::SpawnContext;
     #[allow(unused_imports)]


### PR DESCRIPTION
This removes the `embassy-executor-nightly` feature and instead guards the `fake` module behind the `test-utils` feature. `postcard-rpc` is added to it's own manifest as a dev-dependency so that this feature can be enabled only for (doc) test.

With these changes I'm able to use the crate in my project that uses nightly. Tests in `postcard-rpc` compile and run. When I run `cargo doc` from the `source/postcard-rpc` folder I get a few warnings about unresolved links but that's unrelated to my changes.