### PR TITLE
Allow waiting for client closing

### DIFF
--- a/example/workbook-host/src/bin/comms-01.rs
+++ b/example/workbook-host/src/bin/comms-01.rs
@@ -6,6 +6,18 @@ use tokio::time::interval;
 #[tokio::main]
 pub async fn main() {
     let client = WorkbookClient::new();
+
+    tokio::select! {
+        _ = client.wait_closed() => {
+            println!("Client is closed, exiting...");
+        }
+        _ = run(&client) => {
+            println!("App is done")
+        }
+    }
+}
+
+async fn run(client: &WorkbookClient) {
     let mut ticker = interval(Duration::from_millis(250));
 
     for i in 0..10 {

--- a/example/workbook-host/src/client.rs
+++ b/example/workbook-host/src/client.rs
@@ -44,6 +44,10 @@ impl WorkbookClient {
         Self { client }
     }
 
+    pub async fn wait_closed(&self) {
+        self.client.wait_closed().await;
+    }
+
     pub async fn ping(&self, id: u32) -> Result<u32, WorkbookError<Infallible>> {
         let val = self.client.send_resp::<PingEndpoint>(&id).await?;
         Ok(val)

--- a/source/postcard-rpc/src/host_client/mod.rs
+++ b/source/postcard-rpc/src/host_client/mod.rs
@@ -366,6 +366,11 @@ where
     pub fn is_closed(&self) -> bool {
         self.stopper.is_stopped()
     }
+
+    /// Wait for the host client to be closed
+    pub async fn wait_closed(&self) {
+        self.stopper.wait_stopped().await;
+    }
 }
 
 /// A structure that represents a subscription to the given topic


### PR DESCRIPTION
This PR adds a simple function to the HostClient to allow waiting for a client to be closed. 
There is also a minimal example of the intended usage.