### PR TITLE
Update embassy-usb to 0.3

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -44,12 +44,12 @@ RUSTFLAGS="--cfg=web_sys_unstable_apis" \
 cargo check \
     --manifest-path source/postcard-rpc/Cargo.toml \
     --no-default-features \
-    --features=embassy-usb-0_2-server \
+    --features=embassy-usb-0_3-server \
     --target thumbv7em-none-eabihf
 cargo build \
     --manifest-path source/postcard-rpc/Cargo.toml \
     --no-default-features \
-    --features=embassy-usb-0_2-server \
+    --features=embassy-usb-0_3-server \
     --target thumbv7em-none-eabihf
 
 # Example projects

--- a/example/firmware/Cargo.lock
+++ b/example/firmware/Cargo.lock
@@ -350,8 +350,8 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "embassy-embedded-hal"
-version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=4e5a646f8b1905de014462f5f0441952ec7e209b#4e5a646f8b1905de014462f5f0441952ec7e209b"
+version = "0.2.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=32cff6530fdb81066451cc1d3f1fbbb420e985da#32cff6530fdb81066451cc1d3f1fbbb420e985da"
 dependencies = [
  "embassy-futures",
  "embassy-sync",
@@ -367,13 +367,24 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.5.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=4e5a646f8b1905de014462f5f0441952ec7e209b#4e5a646f8b1905de014462f5f0441952ec7e209b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec648daedd2143466eff4b3e8002024f9f6c1de4ab7666bb679688752624c925"
+dependencies = [
+ "critical-section",
+ "document-features",
+ "embassy-executor-macros 0.4.1",
+]
+
+[[package]]
+name = "embassy-executor"
+version = "0.6.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=32cff6530fdb81066451cc1d3f1fbbb420e985da#32cff6530fdb81066451cc1d3f1fbbb420e985da"
 dependencies = [
  "cortex-m",
  "critical-section",
  "defmt",
  "document-features",
- "embassy-executor-macros",
+ "embassy-executor-macros 0.5.0",
  "embassy-time-driver",
  "embassy-time-queue-driver",
 ]
@@ -381,7 +392,19 @@ dependencies = [
 [[package]]
 name = "embassy-executor-macros"
 version = "0.4.1"
-source = "git+https://github.com/embassy-rs/embassy?rev=4e5a646f8b1905de014462f5f0441952ec7e209b#4e5a646f8b1905de014462f5f0441952ec7e209b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad454accf80050e9cf7a51e994132ba0e56286b31f9317b68703897c328c59b5"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "embassy-executor-macros"
+version = "0.5.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=32cff6530fdb81066451cc1d3f1fbbb420e985da#32cff6530fdb81066451cc1d3f1fbbb420e985da"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -392,12 +415,12 @@ dependencies = [
 [[package]]
 name = "embassy-futures"
 version = "0.1.1"
-source = "git+https://github.com/embassy-rs/embassy?rev=4e5a646f8b1905de014462f5f0441952ec7e209b#4e5a646f8b1905de014462f5f0441952ec7e209b"
+source = "git+https://github.com/embassy-rs/embassy?rev=32cff6530fdb81066451cc1d3f1fbbb420e985da#32cff6530fdb81066451cc1d3f1fbbb420e985da"
 
 [[package]]
 name = "embassy-hal-internal"
-version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=4e5a646f8b1905de014462f5f0441952ec7e209b#4e5a646f8b1905de014462f5f0441952ec7e209b"
+version = "0.2.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=32cff6530fdb81066451cc1d3f1fbbb420e985da#32cff6530fdb81066451cc1d3f1fbbb420e985da"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -408,12 +431,12 @@ dependencies = [
 [[package]]
 name = "embassy-net-driver"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=4e5a646f8b1905de014462f5f0441952ec7e209b#4e5a646f8b1905de014462f5f0441952ec7e209b"
+source = "git+https://github.com/embassy-rs/embassy?rev=32cff6530fdb81066451cc1d3f1fbbb420e985da#32cff6530fdb81066451cc1d3f1fbbb420e985da"
 
 [[package]]
 name = "embassy-net-driver-channel"
-version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=4e5a646f8b1905de014462f5f0441952ec7e209b#4e5a646f8b1905de014462f5f0441952ec7e209b"
+version = "0.3.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=32cff6530fdb81066451cc1d3f1fbbb420e985da#32cff6530fdb81066451cc1d3f1fbbb420e985da"
 dependencies = [
  "embassy-futures",
  "embassy-net-driver",
@@ -422,8 +445,8 @@ dependencies = [
 
 [[package]]
 name = "embassy-rp"
-version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=4e5a646f8b1905de014462f5f0441952ec7e209b#4e5a646f8b1905de014462f5f0441952ec7e209b"
+version = "0.2.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=32cff6530fdb81066451cc1d3f1fbbb420e985da#32cff6530fdb81066451cc1d3f1fbbb420e985da"
 dependencies = [
  "atomic-polyfill",
  "cfg-if",
@@ -454,12 +477,13 @@ dependencies = [
  "rand_core",
  "rp-pac",
  "rp2040-boot2",
+ "sha2-const-stable",
 ]
 
 [[package]]
 name = "embassy-sync"
 version = "0.6.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=4e5a646f8b1905de014462f5f0441952ec7e209b#4e5a646f8b1905de014462f5f0441952ec7e209b"
+source = "git+https://github.com/embassy-rs/embassy?rev=32cff6530fdb81066451cc1d3f1fbbb420e985da#32cff6530fdb81066451cc1d3f1fbbb420e985da"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -471,8 +495,8 @@ dependencies = [
 
 [[package]]
 name = "embassy-time"
-version = "0.3.1"
-source = "git+https://github.com/embassy-rs/embassy?rev=4e5a646f8b1905de014462f5f0441952ec7e209b#4e5a646f8b1905de014462f5f0441952ec7e209b"
+version = "0.3.2"
+source = "git+https://github.com/embassy-rs/embassy?rev=32cff6530fdb81066451cc1d3f1fbbb420e985da#32cff6530fdb81066451cc1d3f1fbbb420e985da"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -490,7 +514,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=4e5a646f8b1905de014462f5f0441952ec7e209b#4e5a646f8b1905de014462f5f0441952ec7e209b"
+source = "git+https://github.com/embassy-rs/embassy?rev=32cff6530fdb81066451cc1d3f1fbbb420e985da#32cff6530fdb81066451cc1d3f1fbbb420e985da"
 dependencies = [
  "document-features",
 ]
@@ -498,12 +522,12 @@ dependencies = [
 [[package]]
 name = "embassy-time-queue-driver"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=4e5a646f8b1905de014462f5f0441952ec7e209b#4e5a646f8b1905de014462f5f0441952ec7e209b"
+source = "git+https://github.com/embassy-rs/embassy?rev=32cff6530fdb81066451cc1d3f1fbbb420e985da#32cff6530fdb81066451cc1d3f1fbbb420e985da"
 
 [[package]]
 name = "embassy-usb"
-version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=4e5a646f8b1905de014462f5f0441952ec7e209b#4e5a646f8b1905de014462f5f0441952ec7e209b"
+version = "0.3.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=32cff6530fdb81066451cc1d3f1fbbb420e985da#32cff6530fdb81066451cc1d3f1fbbb420e985da"
 dependencies = [
  "defmt",
  "embassy-futures",
@@ -518,7 +542,7 @@ dependencies = [
 [[package]]
 name = "embassy-usb-driver"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=4e5a646f8b1905de014462f5f0441952ec7e209b#4e5a646f8b1905de014462f5f0441952ec7e209b"
+source = "git+https://github.com/embassy-rs/embassy?rev=32cff6530fdb81066451cc1d3f1fbbb420e985da#32cff6530fdb81066451cc1d3f1fbbb420e985da"
 dependencies = [
  "defmt",
 ]
@@ -1152,7 +1176,7 @@ dependencies = [
 name = "postcard-rpc"
 version = "0.6.0"
 dependencies = [
- "embassy-executor",
+ "embassy-executor 0.5.0",
  "embassy-sync",
  "embassy-usb",
  "embassy-usb-driver",
@@ -1283,8 +1307,7 @@ dependencies = [
 [[package]]
 name = "rp-pac"
 version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30f6c4c846269293db805e9c77864ff7b923395b480550df44f0868e3765337"
+source = "git+https://github.com/embassy-rs/rp-pac.git?rev=a7f42d25517f7124ad3b4ed492dec8b0f50a0e6c#a7f42d25517f7124ad3b4ed492dec8b0f50a0e6c"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -1369,6 +1392,12 @@ dependencies = [
  "quote",
  "syn 2.0.72",
 ]
+
+[[package]]
+name = "sha2-const-stable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
 
 [[package]]
 name = "siphasher"
@@ -1740,7 +1769,7 @@ dependencies = [
  "cortex-m-rt",
  "defmt",
  "defmt-rtt",
- "embassy-executor",
+ "embassy-executor 0.6.0",
  "embassy-rp",
  "embassy-sync",
  "embassy-time",

--- a/example/firmware/Cargo.lock
+++ b/example/firmware/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "postcard-rpc"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "embassy-executor 0.5.0",
  "embassy-sync",

--- a/example/firmware/Cargo.toml
+++ b/example/firmware/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2021"
 
 [dependencies]
 cortex-m                = { version = "0.7.6", features = ["inline-asm"] }
-embassy-executor        = { version = "0.5.0", features = ["task-arena-size-32768", "arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
-embassy-rp              = { version = "0.1.0", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl"] }
+embassy-executor        = { version = "0.6.0", features = ["task-arena-size-32768", "arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
+embassy-rp              = { version = "0.2.0", features = ["rp2040", "defmt", "unstable-pac", "time-driver", "critical-section-impl"] }
 embassy-sync            = { version = "0.6.0", features = ["defmt"] }
-embassy-time            = { version = "0.3.0", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-usb             = { version = "0.2.0", features = ["defmt"] }
+embassy-time            = { version = "0.3.2", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-usb             = { version = "0.3.0", features = ["defmt"] }
 embedded-hal-bus        = { version = "0.1",   features = ["async"] }
 lis3dh-async            = { version = "0.9.2", features = ["defmt"] }
 panic-probe             = { version = "0.3",   features = ["print-defmt"] }
-postcard-rpc            = { version = "0.6",   features = ["embassy-usb-0_2-server"] }
+postcard-rpc            = { version = "0.6",   features = ["embassy-usb-0_3-server"] }
 postcard                = { version = "1.0.8", features = ["experimental-derive"] }
 portable-atomic         = { version = "1.6.0", features = ["critical-section"] }
 
@@ -38,14 +38,11 @@ codegen-units = 1
 incremental = false
 
 [patch.crates-io]
-# NOTE: Although embassy-usb has released 0.2, we still need to use patched deps for the other various crates
-# for now. See https://github.com/embassy-rs/embassy/issues/2936 for getting other min versions of these
-# crates published.
-embassy-embedded-hal = { git = "https://github.com/embassy-rs/embassy", rev = "4e5a646f8b1905de014462f5f0441952ec7e209b" }
-embassy-executor     = { git = "https://github.com/embassy-rs/embassy", rev = "4e5a646f8b1905de014462f5f0441952ec7e209b" }
-embassy-rp           = { git = "https://github.com/embassy-rs/embassy", rev = "4e5a646f8b1905de014462f5f0441952ec7e209b" }
-embassy-sync         = { git = "https://github.com/embassy-rs/embassy", rev = "4e5a646f8b1905de014462f5f0441952ec7e209b" }
-embassy-time         = { git = "https://github.com/embassy-rs/embassy", rev = "4e5a646f8b1905de014462f5f0441952ec7e209b" }
-embassy-usb          = { git = "https://github.com/embassy-rs/embassy", rev = "4e5a646f8b1905de014462f5f0441952ec7e209b" }
-embassy-usb-driver   = { git = "https://github.com/embassy-rs/embassy", rev = "4e5a646f8b1905de014462f5f0441952ec7e209b" }
+embassy-embedded-hal = { git = "https://github.com/embassy-rs/embassy", rev = "32cff6530fdb81066451cc1d3f1fbbb420e985da" }
+embassy-executor     = { git = "https://github.com/embassy-rs/embassy", rev = "32cff6530fdb81066451cc1d3f1fbbb420e985da" }
+embassy-rp           = { git = "https://github.com/embassy-rs/embassy", rev = "32cff6530fdb81066451cc1d3f1fbbb420e985da" }
+embassy-sync         = { git = "https://github.com/embassy-rs/embassy", rev = "32cff6530fdb81066451cc1d3f1fbbb420e985da" }
+embassy-time         = { git = "https://github.com/embassy-rs/embassy", rev = "32cff6530fdb81066451cc1d3f1fbbb420e985da" }
+embassy-usb          = { git = "https://github.com/embassy-rs/embassy", rev = "32cff6530fdb81066451cc1d3f1fbbb420e985da" }
+embassy-usb-driver   = { git = "https://github.com/embassy-rs/embassy", rev = "32cff6530fdb81066451cc1d3f1fbbb420e985da" }
 postcard-rpc         = { path = "../../source/postcard-rpc" }

--- a/example/firmware/Cargo.toml
+++ b/example/firmware/Cargo.toml
@@ -13,7 +13,7 @@ embassy-usb             = { version = "0.3.0", features = ["defmt"] }
 embedded-hal-bus        = { version = "0.1",   features = ["async"] }
 lis3dh-async            = { version = "0.9.2", features = ["defmt"] }
 panic-probe             = { version = "0.3",   features = ["print-defmt"] }
-postcard-rpc            = { version = "0.6",   features = ["embassy-usb-0_3-server"] }
+postcard-rpc            = { version = "0.7",   features = ["embassy-usb-0_3-server"] }
 postcard                = { version = "1.0.8", features = ["experimental-derive"] }
 portable-atomic         = { version = "1.6.0", features = ["critical-section"] }
 

--- a/example/workbook-host/Cargo.lock
+++ b/example/workbook-host/Cargo.lock
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "postcard-rpc"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "heapless 0.8.0",
  "maitake-sync",

--- a/example/workbook-host/Cargo.toml
+++ b/example/workbook-host/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 path = "../workbook-icd"
 
 [dependencies.postcard-rpc]
-version = "0.6"
+version = "0.7"
 features = [
     "use-std",
     "raw-nusb",

--- a/example/workbook-icd/Cargo.toml
+++ b/example/workbook-icd/Cargo.toml
@@ -13,7 +13,7 @@ version = "1.0"
 features = ["experimental-derive"]
 
 [dependencies.postcard-rpc]
-version = "0.6"
+version = "0.7"
 
 [patch.crates-io]
 postcard-rpc = { path = "../../source/postcard-rpc" }

--- a/source/postcard-rpc-test/Cargo.lock
+++ b/source/postcard-rpc-test/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "postcard-rpc"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "heapless 0.8.0",
  "maitake-sync",

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -18,7 +18,7 @@ features = [
     "use-std",
     "cobs-serial",
     "raw-nusb",
-    "embassy-usb-0_2-server",
+    "embassy-usb-0_3-server",
     "_docs-fix",
     # TODO: What to do about the webusb feature? Can we do separate target builds?
 ]
@@ -107,7 +107,7 @@ optional = true
 #
 
 [dependencies.embassy-usb]
-version = "0.2"
+version = "0.3"
 optional = true
 
 [dependencies.embassy-usb-driver]
@@ -183,7 +183,7 @@ webusb = [
     "dep:js-sys",
     "use-std",
 ]
-embassy-usb-0_2-server = [
+embassy-usb-0_3-server = [
     "dep:embassy-usb",
     "dep:embassy-sync",
     "dep:static_cell",

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postcard-rpc"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["James Munns <james@onevariable.com>"]
 edition = "2021"
 repository = "https://github.com/jamesmunns/postcard-rpc"

--- a/source/postcard-rpc/src/lib.rs
+++ b/source/postcard-rpc/src/lib.rs
@@ -190,7 +190,7 @@ pub mod host_client;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 
-#[cfg(feature = "embassy-usb-0_2-server")]
+#[cfg(feature = "embassy-usb-0_3-server")]
 pub mod target_server;
 
 mod macros;


### PR DESCRIPTION
This also removes support for embassy-usb v0.2. I tried to figure out how to support both, but they require different versions of usbd-hid stuff, which I was unable to resolve.