### PR TITLE
Introduce new v2 hash

### DIFF
--- a/example/firmware/Cargo.lock
+++ b/example/firmware/Cargo.lock
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "postcard-rpc"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "embassy-executor 0.5.0",
  "embassy-sync",

--- a/example/firmware/Cargo.lock
+++ b/example/firmware/Cargo.lock
@@ -151,26 +151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_format"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "cortex-m"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,17 +1135,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
 dependencies = [
  "cobs",
- "const_format",
  "heapless 0.7.17",
- "postcard-derive",
  "serde",
 ]
 
 [[package]]
 name = "postcard-derive"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4b01218787dd4420daf63875163a787a78294ad48a24e9f6fa8c6507759a79"
+checksum = "f9718c21652accb7372d8187f0df8da07eea83b0fff67276c802b15fb6d44d16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1180,10 +1158,22 @@ dependencies = [
  "embassy-sync",
  "embassy-usb",
  "embassy-usb-driver",
+ "futures-util",
  "heapless 0.8.0",
  "postcard",
+ "postcard-schema",
  "serde",
  "static_cell",
+]
+
+[[package]]
+name = "postcard-schema"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a3e7acbdb61449280eb8c54126ecfb10571ec06add5c60d014c675f029e7d2"
+dependencies = [
+ "postcard-derive",
+ "serde",
 ]
 
 [[package]]
@@ -1785,6 +1775,7 @@ dependencies = [
  "portable-atomic",
  "postcard",
  "postcard-rpc",
+ "postcard-schema",
  "smart-leds",
  "static_cell",
  "workbook-icd",
@@ -1794,8 +1785,8 @@ dependencies = [
 name = "workbook-icd"
 version = "0.1.0"
 dependencies = [
- "postcard",
  "postcard-rpc",
+ "postcard-schema",
  "serde",
 ]
 

--- a/example/firmware/Cargo.toml
+++ b/example/firmware/Cargo.toml
@@ -14,7 +14,8 @@ embedded-hal-bus        = { version = "0.1",   features = ["async"] }
 lis3dh-async            = { version = "0.9.2", features = ["defmt"] }
 panic-probe             = { version = "0.3",   features = ["print-defmt"] }
 postcard-rpc            = { version = "0.7",   features = ["embassy-usb-0_3-server"] }
-postcard                = { version = "1.0.8", features = ["experimental-derive"] }
+postcard                = { version = "1.0.8" }
+postcard-schema         = { version = "0.1.0", features = ["derive"] }
 portable-atomic         = { version = "1.6.0", features = ["critical-section"] }
 
 workbook-icd            = { path = "../workbook-icd" }

--- a/example/firmware/Cargo.toml
+++ b/example/firmware/Cargo.toml
@@ -13,7 +13,7 @@ embassy-usb             = { version = "0.3.0", features = ["defmt"] }
 embedded-hal-bus        = { version = "0.1",   features = ["async"] }
 lis3dh-async            = { version = "0.9.2", features = ["defmt"] }
 panic-probe             = { version = "0.3",   features = ["print-defmt"] }
-postcard-rpc            = { version = "0.7",   features = ["embassy-usb-0_3-server"] }
+postcard-rpc            = { version = "0.8",   features = ["embassy-usb-0_3-server"] }
 postcard                = { version = "1.0.8" }
 postcard-schema         = { version = "0.1.0", features = ["derive"] }
 portable-atomic         = { version = "1.6.0", features = ["critical-section"] }

--- a/example/workbook-host/Cargo.lock
+++ b/example/workbook-host/Cargo.lock
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "postcard-rpc"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "heapless 0.8.0",
  "maitake-sync",

--- a/example/workbook-host/Cargo.lock
+++ b/example/workbook-host/Cargo.lock
@@ -99,26 +99,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
-name = "const_format"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "cordyceps"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,18 +446,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
 dependencies = [
  "cobs",
- "const_format",
  "embedded-io",
  "heapless 0.7.17",
- "postcard-derive",
  "serde",
 ]
 
 [[package]]
 name = "postcard-derive"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4b01218787dd4420daf63875163a787a78294ad48a24e9f6fa8c6507759a79"
+checksum = "f9718c21652accb7372d8187f0df8da07eea83b0fff67276c802b15fb6d44d16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -492,11 +470,22 @@ dependencies = [
  "maitake-sync",
  "nusb",
  "postcard",
+ "postcard-schema",
  "serde",
  "thiserror",
  "tokio",
  "tracing",
  "trait-variant",
+]
+
+[[package]]
+name = "postcard-schema"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a3e7acbdb61449280eb8c54126ecfb10571ec06add5c60d014c675f029e7d2"
+dependencies = [
+ "postcard-derive",
+ "serde",
 ]
 
 [[package]]
@@ -827,12 +816,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1025,7 @@ name = "workbook-host-client"
 version = "0.1.0"
 dependencies = [
  "postcard-rpc",
+ "postcard-schema",
  "tokio",
  "workbook-icd",
 ]
@@ -1050,7 +1034,7 @@ dependencies = [
 name = "workbook-icd"
 version = "0.1.0"
 dependencies = [
- "postcard",
  "postcard-rpc",
+ "postcard-schema",
  "serde",
 ]

--- a/example/workbook-host/Cargo.toml
+++ b/example/workbook-host/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 path = "../workbook-icd"
 
 [dependencies.postcard-rpc]
-version = "0.7"
+version = "0.8"
 features = [
     "use-std",
     "raw-nusb",

--- a/example/workbook-host/Cargo.toml
+++ b/example/workbook-host/Cargo.toml
@@ -13,6 +13,10 @@ features = [
     "raw-nusb",
 ]
 
+[dependencies.postcard-schema]
+version = "0.1"
+features = ["derive"]
+
 [dependencies.tokio]
 version = "1.37.0"
 features = [

--- a/example/workbook-icd/Cargo.lock
+++ b/example/workbook-icd/Cargo.lock
@@ -30,26 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
-name = "const_format"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "critical-section"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,17 +94,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
 dependencies = [
  "cobs",
- "const_format",
  "heapless 0.7.17",
- "postcard-derive",
  "serde",
 ]
 
 [[package]]
 name = "postcard-derive"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4b01218787dd4420daf63875163a787a78294ad48a24e9f6fa8c6507759a79"
+checksum = "f9718c21652accb7372d8187f0df8da07eea83b0fff67276c802b15fb6d44d16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -133,10 +111,21 @@ dependencies = [
 
 [[package]]
 name = "postcard-rpc"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "heapless 0.8.0",
  "postcard",
+ "postcard-schema",
+ "serde",
+]
+
+[[package]]
+name = "postcard-schema"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a3e7acbdb61449280eb8c54126ecfb10571ec06add5c60d014c675f029e7d2"
+dependencies = [
+ "postcard-derive",
  "serde",
 ]
 
@@ -243,16 +232,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
 name = "workbook-icd"
 version = "0.1.0"
 dependencies = [
- "postcard",
  "postcard-rpc",
+ "postcard-schema",
  "serde",
 ]

--- a/example/workbook-icd/Cargo.toml
+++ b/example/workbook-icd/Cargo.toml
@@ -9,7 +9,7 @@ features = ["derive"]
 default-features = false
 
 [dependencies.postcard-rpc]
-version = "0.7"
+version = "0.8"
 
 [dependencies.postcard-schema]
 version = "0.1"

--- a/example/workbook-icd/Cargo.toml
+++ b/example/workbook-icd/Cargo.toml
@@ -8,12 +8,12 @@ version = "1.0"
 features = ["derive"]
 default-features = false
 
-[dependencies.postcard]
-version = "1.0"
-features = ["experimental-derive"]
-
 [dependencies.postcard-rpc]
 version = "0.7"
+
+[dependencies.postcard-schema]
+version = "0.1"
+features = ["derive"]
 
 [patch.crates-io]
 postcard-rpc = { path = "../../source/postcard-rpc" }

--- a/example/workbook-icd/src/lib.rs
+++ b/example/workbook-icd/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use postcard::experimental::schema::Schema;
+use postcard_schema::Schema;
 use postcard_rpc::{endpoint, topic};
 use serde::{Deserialize, Serialize};
 

--- a/source/postcard-rpc-test/Cargo.lock
+++ b/source/postcard-rpc-test/Cargo.lock
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "postcard-rpc"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "heapless 0.8.0",
  "maitake-sync",

--- a/source/postcard-rpc-test/Cargo.lock
+++ b/source/postcard-rpc-test/Cargo.lock
@@ -362,7 +362,7 @@ dependencies = [
  "const_format",
  "embedded-io",
  "heapless 0.7.16",
- "postcard-derive",
+ "postcard-derive 0.1.1",
  "serde",
 ]
 
@@ -378,12 +378,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9718c21652accb7372d8187f0df8da07eea83b0fff67276c802b15fb6d44d16"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "postcard-rpc"
 version = "0.7.0"
 dependencies = [
  "heapless 0.8.0",
  "maitake-sync",
  "postcard",
+ "postcard-schema",
  "serde",
  "thiserror",
  "tokio",
@@ -397,8 +409,19 @@ version = "0.1.0"
 dependencies = [
  "postcard",
  "postcard-rpc",
+ "postcard-schema",
  "serde",
  "tokio",
+]
+
+[[package]]
+name = "postcard-schema"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a3e7acbdb61449280eb8c54126ecfb10571ec06add5c60d014c675f029e7d2"
+dependencies = [
+ "postcard-derive 0.2.0",
+ "serde",
 ]
 
 [[package]]

--- a/source/postcard-rpc-test/Cargo.toml
+++ b/source/postcard-rpc-test/Cargo.toml
@@ -15,6 +15,10 @@ features = ["derive"]
 path = "../postcard-rpc"
 features = ["use-std", "test-utils"]
 
+[dependencies.postcard-schema]
+version = "0.1.0"
+features = ["derive"]
+
 [dependencies.tokio]
 version = "1.34.0"
 features = ["rt", "macros", "sync", "time"]

--- a/source/postcard-rpc-test/tests/basic.rs
+++ b/source/postcard-rpc-test/tests/basic.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, time::Duration};
 
-use postcard::experimental::schema::Schema;
+use postcard_schema::Schema;
 use postcard_rpc::test_utils::local_setup;
 use postcard_rpc::{
     endpoint, headered::to_stdvec_keyed, topic, Dispatch, Endpoint, Key, Topic, WireHeader,

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postcard-rpc"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["James Munns <james@onevariable.com>"]
 edition = "2021"
 repository = "https://github.com/jamesmunns/postcard-rpc"

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -207,3 +207,6 @@ hashv2 = []
 # that feature when `--all-features` is set. This feature is considered unstable
 # and should not be relied upon.
 _docs-fix = ["dep:ssmarshal"]
+
+[patch.crates-io]
+postcard = { git = "https://github.com/jamesmunns/postcard", rev = "dbb730afa00d7a556ce02cb3ae1d984832d6c798" }

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -20,6 +20,7 @@ features = [
     "raw-nusb",
     "embassy-usb-0_3-server",
     "_docs-fix",
+    "hashv2",
     # TODO: What to do about the webusb feature? Can we do separate target builds?
 ]
 
@@ -190,6 +191,9 @@ embassy-usb-0_3-server = [
     "dep:embassy-usb-driver",
     "dep:embassy-executor",
 ]
+
+# Use the newer, NOT BACKWARDS COMPATIBLE, hashing algorithm for schemas
+hashv2 = []
 
 # NOTE: This exists because `embassy-usb` indirectly relies on ssmarshal
 # which doesn't work on `std` builds without the `std` feature. This causes

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -20,7 +20,6 @@ features = [
     "raw-nusb",
     "embassy-usb-0_3-server",
     "_docs-fix",
-    "hashv2",
     # TODO: What to do about the webusb feature? Can we do separate target builds?
 ]
 
@@ -199,9 +198,6 @@ embassy-usb-0_3-server = [
     "dep:embassy-executor",
     "dep:futures-util",
 ]
-
-# Use the newer, NOT BACKWARDS COMPATIBLE, hashing algorithm for schemas
-hashv2 = []
 
 # NOTE: This exists because `embassy-usb` indirectly relies on ssmarshal
 # which doesn't work on `std` builds without the `std` feature. This causes

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -127,6 +127,11 @@ optional = true
 version = "0.5"
 optional = true
 
+[dependencies.futures-util]
+version = "0.3"
+optional = true
+default-features = false
+
 [dev-dependencies]
 postcard-rpc = { path = "../postcard-rpc", features = ["test-utils"] }
 
@@ -190,6 +195,7 @@ embassy-usb-0_3-server = [
     "dep:static_cell",
     "dep:embassy-usb-driver",
     "dep:embassy-executor",
+    "dep:futures-util",
 ]
 
 # Use the newer, NOT BACKWARDS COMPATIBLE, hashing algorithm for schemas

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -28,8 +28,9 @@ features = [
 cobs = { version = "0.2.3", optional = true, default-features = false }
 defmt = { version = "0.3.5", optional = true }
 heapless = "0.8.0"
-postcard = { version = "1.0.8", features = ["experimental-derive"] }
+postcard = { version = "1.0.8" }
 serde = { version = "1.0.192", default-features = false, features = ["derive"] }
+postcard-schema = { version = "0.1.0", features = ["derive"] }
 
 #
 # std-only features
@@ -146,11 +147,12 @@ features = ["std"]
 
 [features]
 default = []
-test-utils = ["use-std"]
+test-utils = ["use-std", "postcard-schema/use-std"]
 use-std = [
     "dep:maitake-sync",
     "dep:tokio",
     "postcard/use-std",
+    "postcard-schema/use-std",
     "dep:thiserror",
     "dep:tracing",
     "dep:trait-variant",
@@ -207,6 +209,3 @@ hashv2 = []
 # that feature when `--all-features` is set. This feature is considered unstable
 # and should not be relied upon.
 _docs-fix = ["dep:ssmarshal"]
-
-[patch.crates-io]
-postcard = { git = "https://github.com/jamesmunns/postcard", rev = "dbb730afa00d7a556ce02cb3ae1d984832d6c798" }

--- a/source/postcard-rpc/src/hash.rs
+++ b/source/postcard-rpc/src/hash.rs
@@ -385,16 +385,34 @@ pub mod fnv1a64 {
 #[cfg(all(test, feature = "hashv2"))]
 mod test {
     use super::fnv1a64::hash_ty_path;
+    use super::*;
 
     #[test]
-    fn type_punning() {
+    fn type_punning_good() {
         let hash_1 = hash_ty_path::<Vec<u8>>("test_path");
         let hash_2 = hash_ty_path::<&[u8]>("test_path");
         let hash_3 = hash_ty_path::<Vec<u16>>("test_path");
         let hash_4 = hash_ty_path::<&[u16]>("test_path");
+        let hash_5 = hash_ty_path::<Vec<u8>>("test_patt");
+        let hash_6 = hash_ty_path::<&[u8]>("test_patt");
         assert_eq!(hash_1, hash_2);
         assert_eq!(hash_3, hash_4);
         assert_ne!(hash_1, hash_3);
         assert_ne!(hash_2, hash_4);
+        assert_ne!(hash_1, hash_5);
+        assert_ne!(hash_2, hash_6);
+    }
+
+    #[test]
+    fn type_punning_questionable() {
+        #[derive(Schema)]
+        struct Wrapper1(u8);
+
+        #[derive(Schema)]
+        struct Wrapper2(u8);
+
+        let hash_1 = hash_ty_path::<Wrapper1>("test_path");
+        let hash_2 = hash_ty_path::<Wrapper2>("test_path");
+        assert_eq!(hash_1, hash_2);
     }
 }

--- a/source/postcard-rpc/src/hash.rs
+++ b/source/postcard-rpc/src/hash.rs
@@ -46,6 +46,7 @@ impl Default for Fnv1a64Hasher {
     }
 }
 
+#[cfg(not(feature = "hashv2"))]
 pub mod fnv1a64 {
     use super::*;
 
@@ -197,5 +198,203 @@ pub mod fnv1a64 {
     const fn hash_named_value(state: u64, nt: &NamedValue) -> u64 {
         let state = hash_update(state, nt.name.as_bytes());
         hash_named_type(state, nt.ty)
+    }
+}
+
+#[cfg(feature = "hashv2")]
+pub mod fnv1a64 {
+    use super::*;
+
+    pub const fn hash_ty_path<T: Schema + ?Sized>(path: &str) -> [u8; 8] {
+        let schema = T::SCHEMA;
+        let state = hash_update_str(Fnv1a64Hasher::BASIS, path);
+        hash_named_type(state, schema).to_le_bytes()
+    }
+
+    const fn hash_update(mut state: u64, bytes: &[u8]) -> u64 {
+        let mut idx = 0;
+        while idx < bytes.len() {
+            let ext = bytes[idx] as u64;
+            state ^= ext;
+            state = state.wrapping_mul(Fnv1a64Hasher::PRIME);
+            idx += 1;
+        }
+        state
+    }
+
+    const fn hash_update_str(state: u64, s: &str) -> u64 {
+        hash_update(state, s.as_bytes())
+    }
+
+    const fn hash_sdm_type(state: u64, sdmty: &'static SdmTy) -> u64 {
+        // The actual values we use here don't matter that much (as far as I know),
+        // as long as the values for each variant are unique. I am unsure of the
+        // implications of doing a TON of single byte calls to `update`, it may be
+        // worth doing some buffering, and only calling update every 4/8/16 bytes
+        // instead, if performance is a concern.
+        //
+        // As of initial implementation, I'm mostly concerned with "does it work",
+        // as hashing is typically only done on startup.
+        //
+        // Using all primes that fit into a single byte:
+        //
+        // all_primes = [
+        //     0x02, 0x03, 0x05, 0x07, 0x0B, 0x0D, 0x11, 0x13,
+        //     0x17, 0x1D, 0x1F, 0x25, 0x29, 0x2B, 0x2F, 0x35,
+        //     0x3B, 0x3D, 0x43, 0x47, 0x49, 0x4F, 0x53, 0x59,
+        //     0x61, 0x65, 0x67, 0x6B, 0x6D, 0x71, 0x7F, 0x83,
+        //     0x89, 0x8B, 0x95, 0x97, 0x9D, 0xA3, 0xA7, 0xAD,
+        //     0xB3, 0xB5, 0xBF, 0xC1, 0xC5, 0xC7, 0xD3, 0xDF,
+        //     0xE3, 0xE5, 0xE9, 0xEF, 0xF1, 0xFB,
+        // ];
+        // shuffled_primes = [
+        //     0x11, 0xC5, 0x3D, 0x95, 0x1D, 0x0D, 0x0B, 0x02,
+        //     0x83, 0xD3, 0x13, 0x8B, 0x6B, 0xAD, 0xEF, 0x71,
+        //     0xC1, 0x25, 0x65, 0x6D, 0x47, 0xBF, 0xB5, 0x9D,
+        //     0xDF, 0x03, 0xA7, 0x05, 0xC7, 0x4F, 0x7F, 0x67,
+        //     0xE9, 0xB3, 0xE5, 0x2B, 0x97, 0xFB, 0x61, 0x3B,
+        //     0x1F, 0xA3, 0x35, 0x43, 0x89, 0x49, 0xE3, 0x07,
+        //     0x53, 0xF1, 0x17, 0x2F, 0x29, 0x59,
+        // ];
+        match sdmty {
+            SdmTy::Bool => hash_update(state, &[0x11]),
+            SdmTy::I8 => hash_update(state, &[0xC5]),
+            SdmTy::U8 => hash_update(state, &[0x3D]),
+            SdmTy::Varint(v) => {
+                let state = hash_update(state, &[0x95]);
+                match v {
+                    Varint::I16 => hash_update(state, &[0x1D]),
+                    Varint::I32 => hash_update(state, &[0x0D]),
+                    Varint::I64 => hash_update(state, &[0x0B]),
+                    Varint::I128 => hash_update(state, &[0x02]),
+                    Varint::U16 => hash_update(state, &[0x83]),
+                    Varint::U32 => hash_update(state, &[0xD3]),
+                    Varint::U64 => hash_update(state, &[0x13]),
+                    Varint::U128 => hash_update(state, &[0x8B]),
+                    Varint::Usize => hash_update(state, &[0x6B]),
+                    Varint::Isize => hash_update(state, &[0xAD]),
+                }
+            }
+            SdmTy::F32 => hash_update(state, &[0xEF]),
+            SdmTy::F64 => hash_update(state, &[0x71]),
+            SdmTy::Char => hash_update(state, &[0xC1]),
+            SdmTy::String => hash_update(state, &[0x25]),
+            SdmTy::ByteArray => hash_update(state, &[0x65]),
+            SdmTy::Option(nt) => {
+                let state = hash_update(state, &[0x6D]);
+                hash_named_type(state, nt)
+            }
+            SdmTy::Unit => hash_update(state, &[0x47]),
+            SdmTy::UnitStruct => hash_update(state, &[0xBF]),
+            SdmTy::UnitVariant => hash_update(state, &[0xB5]),
+            SdmTy::NewtypeStruct(nt) => {
+                let state = hash_update(state, &[0x9D]);
+                hash_named_type(state, nt)
+            }
+            SdmTy::NewtypeVariant(nt) => {
+                let state = hash_update(state, &[0xDF]);
+                hash_named_type(state, nt)
+            }
+            SdmTy::Seq(nt) => {
+                let state = hash_update(state, &[0x03]);
+                hash_named_type(state, nt)
+            }
+            SdmTy::Tuple(nts) => {
+                let mut state = hash_update(state, &[0xA7]);
+                let mut idx = 0;
+                while idx < nts.len() {
+                    state = hash_named_type(state, nts[idx]);
+                    idx += 1;
+                }
+                state
+            }
+            SdmTy::TupleStruct(nts) => {
+                let mut state = hash_update(state, &[0x05]);
+                let mut idx = 0;
+                while idx < nts.len() {
+                    state = hash_named_type(state, nts[idx]);
+                    idx += 1;
+                }
+                state
+            }
+            SdmTy::TupleVariant(nts) => {
+                let mut state = hash_update(state, &[0xC7]);
+                let mut idx = 0;
+                while idx < nts.len() {
+                    state = hash_named_type(state, nts[idx]);
+                    idx += 1;
+                }
+                state
+            }
+            SdmTy::Map { key, val } => {
+                let state = hash_update(state, &[0x4F]);
+                let state = hash_named_type(state, key);
+                hash_named_type(state, val)
+            }
+            SdmTy::Struct(nvs) => {
+                let mut state = hash_update(state, &[0x7F]);
+                let mut idx = 0;
+                while idx < nvs.len() {
+                    state = hash_named_value(state, nvs[idx]);
+                    idx += 1;
+                }
+                state
+            }
+            SdmTy::StructVariant(nvs) => {
+                let mut state = hash_update(state, &[0x67]);
+                let mut idx = 0;
+                while idx < nvs.len() {
+                    state = hash_named_value(state, nvs[idx]);
+                    idx += 1;
+                }
+                state
+            }
+            SdmTy::Enum(nvs) => {
+                let mut state = hash_update(state, &[0xE9]);
+                let mut idx = 0;
+                while idx < nvs.len() {
+                    state = hash_named_variant(state, nvs[idx]);
+                    idx += 1;
+                }
+                state
+            }
+        }
+    }
+
+    const fn hash_named_type(state: u64, nt: &NamedType) -> u64 {
+        // NOTE: We do *not* hash the name of the type in hashv2. This
+        // is to allow "safe" type punning, e.g. treating `Vec<u8>` and
+        // `&[u8]` as compatible types, when talking between std and no-std
+        // targets
+        //
+        // let state = hash_update(state, nt.name.as_bytes());
+        hash_sdm_type(state, nt.ty)
+    }
+
+    const fn hash_named_variant(state: u64, nt: &NamedVariant) -> u64 {
+        let state = hash_update(state, nt.name.as_bytes());
+        hash_sdm_type(state, nt.ty)
+    }
+
+    const fn hash_named_value(state: u64, nt: &NamedValue) -> u64 {
+        let state = hash_update(state, nt.name.as_bytes());
+        hash_named_type(state, nt.ty)
+    }
+}
+
+#[cfg(all(test, feature = "hashv2"))]
+mod test {
+    use super::fnv1a64::hash_ty_path;
+
+    #[test]
+    fn type_punning() {
+        let hash_1 = hash_ty_path::<Vec<u8>>("test_path");
+        let hash_2 = hash_ty_path::<&[u8]>("test_path");
+        let hash_3 = hash_ty_path::<Vec<u16>>("test_path");
+        let hash_4 = hash_ty_path::<&[u16]>("test_path");
+        assert_eq!(hash_1, hash_2);
+        assert_eq!(hash_3, hash_4);
+        assert_ne!(hash_1, hash_3);
+        assert_ne!(hash_2, hash_4);
     }
 }

--- a/source/postcard-rpc/src/hash.rs
+++ b/source/postcard-rpc/src/hash.rs
@@ -403,6 +403,7 @@ mod test {
         assert_ne!(hash_2, hash_6);
     }
 
+    // TODO: It is questionable if I like this outcome
     #[test]
     fn type_punning_questionable() {
         #[derive(Schema)]

--- a/source/postcard-rpc/src/hash.rs
+++ b/source/postcard-rpc/src/hash.rs
@@ -182,6 +182,7 @@ pub mod fnv1a64 {
                 }
                 state
             }
+            SdmTy::Schema => hash_update(state, &[23]),
         }
     }
 
@@ -358,6 +359,7 @@ pub mod fnv1a64 {
                 }
                 state
             }
+            SdmTy::Schema => hash_update(state, &[0xB3]),
         }
     }
 
@@ -528,6 +530,7 @@ pub mod fnv1a64_owned {
                 }
                 state
             }
+            OwnedSdmTy::Schema => hash_update(state, &[0xB3]),
         }
     }
 

--- a/source/postcard-rpc/src/hash.rs
+++ b/source/postcard-rpc/src/hash.rs
@@ -211,7 +211,7 @@ pub mod fnv1a64 {
         hash_named_type(state, schema).to_le_bytes()
     }
 
-    const fn hash_update(mut state: u64, bytes: &[u8]) -> u64 {
+    pub(crate) const fn hash_update(mut state: u64, bytes: &[u8]) -> u64 {
         let mut idx = 0;
         while idx < bytes.len() {
             let ext = bytes[idx] as u64;
@@ -222,7 +222,7 @@ pub mod fnv1a64 {
         state
     }
 
-    const fn hash_update_str(state: u64, s: &str) -> u64 {
+    pub(crate) const fn hash_update_str(state: u64, s: &str) -> u64 {
         hash_update(state, s.as_bytes())
     }
 
@@ -382,6 +382,174 @@ pub mod fnv1a64 {
     }
 }
 
+#[cfg(all(feature = "hashv2", feature = "use-std"))]
+pub mod fnv1a64_owned {
+    use postcard::experimental::schema::{OwnedNamedType, OwnedNamedValue, OwnedNamedVariant, OwnedSdmTy};
+
+    use super::*;
+    use super::fnv1a64::*;
+
+    pub fn hash_ty_path_owned(path: &str, nt: &OwnedNamedType) -> [u8; 8] {
+        let state = hash_update_str(Fnv1a64Hasher::BASIS, path);
+        hash_named_type_owned(state, nt).to_le_bytes()
+    }
+
+    fn hash_sdm_type_owned(state: u64, sdmty: &OwnedSdmTy) -> u64 {
+        // The actual values we use here don't matter that much (as far as I know),
+        // as long as the values for each variant are unique. I am unsure of the
+        // implications of doing a TON of single byte calls to `update`, it may be
+        // worth doing some buffering, and only calling update every 4/8/16 bytes
+        // instead, if performance is a concern.
+        //
+        // As of initial implementation, I'm mostly concerned with "does it work",
+        // as hashing is typically only done on startup.
+        //
+        // Using all primes that fit into a single byte:
+        //
+        // all_primes = [
+        //     0x02, 0x03, 0x05, 0x07, 0x0B, 0x0D, 0x11, 0x13,
+        //     0x17, 0x1D, 0x1F, 0x25, 0x29, 0x2B, 0x2F, 0x35,
+        //     0x3B, 0x3D, 0x43, 0x47, 0x49, 0x4F, 0x53, 0x59,
+        //     0x61, 0x65, 0x67, 0x6B, 0x6D, 0x71, 0x7F, 0x83,
+        //     0x89, 0x8B, 0x95, 0x97, 0x9D, 0xA3, 0xA7, 0xAD,
+        //     0xB3, 0xB5, 0xBF, 0xC1, 0xC5, 0xC7, 0xD3, 0xDF,
+        //     0xE3, 0xE5, 0xE9, 0xEF, 0xF1, 0xFB,
+        // ];
+        // shuffled_primes = [
+        //     0x11, 0xC5, 0x3D, 0x95, 0x1D, 0x0D, 0x0B, 0x02,
+        //     0x83, 0xD3, 0x13, 0x8B, 0x6B, 0xAD, 0xEF, 0x71,
+        //     0xC1, 0x25, 0x65, 0x6D, 0x47, 0xBF, 0xB5, 0x9D,
+        //     0xDF, 0x03, 0xA7, 0x05, 0xC7, 0x4F, 0x7F, 0x67,
+        //     0xE9, 0xB3, 0xE5, 0x2B, 0x97, 0xFB, 0x61, 0x3B,
+        //     0x1F, 0xA3, 0x35, 0x43, 0x89, 0x49, 0xE3, 0x07,
+        //     0x53, 0xF1, 0x17, 0x2F, 0x29, 0x59,
+        // ];
+        match sdmty {
+            OwnedSdmTy::Bool => hash_update(state, &[0x11]),
+            OwnedSdmTy::I8 => hash_update(state, &[0xC5]),
+            OwnedSdmTy::U8 => hash_update(state, &[0x3D]),
+            OwnedSdmTy::Varint(v) => {
+                let state = hash_update(state, &[0x95]);
+                match v {
+                    Varint::I16 => hash_update(state, &[0x1D]),
+                    Varint::I32 => hash_update(state, &[0x0D]),
+                    Varint::I64 => hash_update(state, &[0x0B]),
+                    Varint::I128 => hash_update(state, &[0x02]),
+                    Varint::U16 => hash_update(state, &[0x83]),
+                    Varint::U32 => hash_update(state, &[0xD3]),
+                    Varint::U64 => hash_update(state, &[0x13]),
+                    Varint::U128 => hash_update(state, &[0x8B]),
+                    Varint::Usize => hash_update(state, &[0x6B]),
+                    Varint::Isize => hash_update(state, &[0xAD]),
+                }
+            }
+            OwnedSdmTy::F32 => hash_update(state, &[0xEF]),
+            OwnedSdmTy::F64 => hash_update(state, &[0x71]),
+            OwnedSdmTy::Char => hash_update(state, &[0xC1]),
+            OwnedSdmTy::String => hash_update(state, &[0x25]),
+            OwnedSdmTy::ByteArray => hash_update(state, &[0x65]),
+            OwnedSdmTy::Option(nt) => {
+                let state = hash_update(state, &[0x6D]);
+                hash_named_type_owned(state, nt)
+            }
+            OwnedSdmTy::Unit => hash_update(state, &[0x47]),
+            OwnedSdmTy::UnitStruct => hash_update(state, &[0xBF]),
+            OwnedSdmTy::UnitVariant => hash_update(state, &[0xB5]),
+            OwnedSdmTy::NewtypeStruct(nt) => {
+                let state = hash_update(state, &[0x9D]);
+                hash_named_type_owned(state, nt)
+            }
+            OwnedSdmTy::NewtypeVariant(nt) => {
+                let state = hash_update(state, &[0xDF]);
+                hash_named_type_owned(state, nt)
+            }
+            OwnedSdmTy::Seq(nt) => {
+                let state = hash_update(state, &[0x03]);
+                hash_named_type_owned(state, nt)
+            }
+            OwnedSdmTy::Tuple(nts) => {
+                let mut state = hash_update(state, &[0xA7]);
+                let mut idx = 0;
+                while idx < nts.len() {
+                    state = hash_named_type_owned(state, &nts[idx]);
+                    idx += 1;
+                }
+                state
+            }
+            OwnedSdmTy::TupleStruct(nts) => {
+                let mut state = hash_update(state, &[0x05]);
+                let mut idx = 0;
+                while idx < nts.len() {
+                    state = hash_named_type_owned(state, &nts[idx]);
+                    idx += 1;
+                }
+                state
+            }
+            OwnedSdmTy::TupleVariant(nts) => {
+                let mut state = hash_update(state, &[0xC7]);
+                let mut idx = 0;
+                while idx < nts.len() {
+                    state = hash_named_type_owned(state, &nts[idx]);
+                    idx += 1;
+                }
+                state
+            }
+            OwnedSdmTy::Map { key, val } => {
+                let state = hash_update(state, &[0x4F]);
+                let state = hash_named_type_owned(state, key);
+                hash_named_type_owned(state, val)
+            }
+            OwnedSdmTy::Struct(nvs) => {
+                let mut state = hash_update(state, &[0x7F]);
+                let mut idx = 0;
+                while idx < nvs.len() {
+                    state = hash_named_value_owned(state, &nvs[idx]);
+                    idx += 1;
+                }
+                state
+            }
+            OwnedSdmTy::StructVariant(nvs) => {
+                let mut state = hash_update(state, &[0x67]);
+                let mut idx = 0;
+                while idx < nvs.len() {
+                    state = hash_named_value_owned(state, &nvs[idx]);
+                    idx += 1;
+                }
+                state
+            }
+            OwnedSdmTy::Enum(nvs) => {
+                let mut state = hash_update(state, &[0xE9]);
+                let mut idx = 0;
+                while idx < nvs.len() {
+                    state = hash_named_variant_owned(state, &nvs[idx]);
+                    idx += 1;
+                }
+                state
+            }
+        }
+    }
+
+    fn hash_named_type_owned(state: u64, nt: &OwnedNamedType) -> u64 {
+        // NOTE: We do *not* hash the name of the type in hashv2. This
+        // is to allow "safe" type punning, e.g. treating `Vec<u8>` and
+        // `&[u8]` as compatible types, when talking between std and no-std
+        // targets
+        //
+        // let state = hash_update(state, nt.name.as_bytes());
+        hash_sdm_type_owned(state, &nt.ty)
+    }
+
+    fn hash_named_variant_owned(state: u64, nt: &OwnedNamedVariant) -> u64 {
+        let state = hash_update(state, nt.name.as_bytes());
+        hash_sdm_type_owned(state, &nt.ty)
+    }
+
+    fn hash_named_value_owned(state: u64, nt: &OwnedNamedValue) -> u64 {
+        let state = hash_update(state, nt.name.as_bytes());
+        hash_named_type_owned(state, &nt.ty)
+    }
+}
+
 #[cfg(all(test, feature = "hashv2"))]
 mod test {
     use super::fnv1a64::hash_ty_path;
@@ -407,9 +575,11 @@ mod test {
     #[test]
     fn type_punning_questionable() {
         #[derive(Schema)]
+        #[allow(unused)]
         struct Wrapper1(u8);
 
         #[derive(Schema)]
+        #[allow(unused)]
         struct Wrapper2(u8);
 
         let hash_1 = hash_ty_path::<Wrapper1>("test_path");

--- a/source/postcard-rpc/src/hash.rs
+++ b/source/postcard-rpc/src/hash.rs
@@ -384,10 +384,12 @@ pub mod fnv1a64 {
 
 #[cfg(all(feature = "hashv2", feature = "use-std"))]
 pub mod fnv1a64_owned {
-    use postcard::experimental::schema::{OwnedNamedType, OwnedNamedValue, OwnedNamedVariant, OwnedSdmTy};
+    use postcard::experimental::schema::{
+        OwnedNamedType, OwnedNamedValue, OwnedNamedVariant, OwnedSdmTy,
+    };
 
-    use super::*;
     use super::fnv1a64::*;
+    use super::*;
 
     pub fn hash_ty_path_owned(path: &str, nt: &OwnedNamedType) -> [u8; 8] {
         let state = hash_update_str(Fnv1a64Hasher::BASIS, path);

--- a/source/postcard-rpc/src/headered.rs
+++ b/source/postcard-rpc/src/headered.rs
@@ -2,10 +2,11 @@
 
 use crate::{Key, WireHeader};
 use postcard::{
-    experimental::schema::Schema,
     ser_flavors::{Cobs, Flavor as SerFlavor, Slice},
     Serializer,
 };
+use postcard_schema::Schema;
+
 use serde::Serialize;
 
 struct Headered<B: SerFlavor> {

--- a/source/postcard-rpc/src/host_client/mod.rs
+++ b/source/postcard-rpc/src/host_client/mod.rs
@@ -16,7 +16,7 @@ use maitake_sync::{
     wait_map::{WaitError, WakeOutcome},
     WaitMap,
 };
-use postcard::experimental::schema::Schema;
+use postcard_schema::Schema;
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::{
     select,

--- a/source/postcard-rpc/src/host_client/mod.rs
+++ b/source/postcard-rpc/src/host_client/mod.rs
@@ -343,12 +343,7 @@ where
         })
     }
 
-    pub async fn subscribe_raw(
-        &self,
-        key: Key,
-        depth: usize,
-    ) -> Result<RawSubscription, IoClosed>
-    {
+    pub async fn subscribe_raw(&self, key: Key, depth: usize) -> Result<RawSubscription, IoClosed> {
         let cancel_fut = self.stopper.wait_stopped();
         let operate_fut = self.subscribe_inner_raw(key, depth);
         select! {
@@ -362,19 +357,13 @@ where
         &self,
         key: Key,
         depth: usize,
-    ) -> Result<RawSubscription, IoClosed>
-    {
+    ) -> Result<RawSubscription, IoClosed> {
         let (tx, rx) = tokio::sync::mpsc::channel(depth);
         self.subber
-            .send(SubInfo {
-                key,
-                tx,
-            })
+            .send(SubInfo { key, tx })
             .await
             .map_err(|_| IoClosed)?;
-        Ok(RawSubscription {
-            rx,
-        })
+        Ok(RawSubscription { rx })
     }
 
     /// Permanently close the connection to the client
@@ -403,8 +392,7 @@ pub struct RawSubscription {
     rx: Receiver<RpcFrame>,
 }
 
-impl RawSubscription
-{
+impl RawSubscription {
     /// Await a message for the given subscription.
     ///
     /// Returns [None]` if the subscription was closed

--- a/source/postcard-rpc/src/host_client/raw_nusb.rs
+++ b/source/postcard-rpc/src/host_client/raw_nusb.rs
@@ -4,7 +4,7 @@ use nusb::{
     transfer::{Queue, RequestBuffer, TransferError},
     DeviceInfo,
 };
-use postcard::experimental::schema::Schema;
+use postcard_schema::Schema;
 use serde::de::DeserializeOwned;
 
 use crate::host_client::{HostClient, WireRx, WireSpawn, WireTx};
@@ -49,7 +49,7 @@ where
     /// ```rust,no_run
     /// use postcard_rpc::host_client::HostClient;
     /// use serde::{Serialize, Deserialize};
-    /// use postcard::experimental::schema::Schema;
+    /// use postcard_schema::Schema;
     ///
     /// /// A "wire error" type your server can use to respond to any
     /// /// kind of request, for example if deserializing a request fails
@@ -109,7 +109,7 @@ where
     /// ```rust,no_run
     /// use postcard_rpc::host_client::HostClient;
     /// use serde::{Serialize, Deserialize};
-    /// use postcard::experimental::schema::Schema;
+    /// use postcard_schema::Schema;
     ///
     /// /// A "wire error" type your server can use to respond to any
     /// /// kind of request, for example if deserializing a request fails

--- a/source/postcard-rpc/src/host_client/serial.rs
+++ b/source/postcard-rpc/src/host_client/serial.rs
@@ -1,7 +1,7 @@
 use std::{collections::VecDeque, future::Future};
 
 use cobs::encode_vec;
-use postcard::experimental::schema::Schema;
+use postcard_schema::Schema;
 use serde::de::DeserializeOwned;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadHalf, WriteHalf};
 use tokio_serial::{SerialPortBuilderExt, SerialStream};
@@ -32,7 +32,7 @@ where
     /// ```rust,no_run
     /// use postcard_rpc::host_client::HostClient;
     /// use serde::{Serialize, Deserialize};
-    /// use postcard::experimental::schema::Schema;
+    /// use postcard_schema::Schema;
     ///
     /// /// A "wire error" type your server can use to respond to any
     /// /// kind of request, for example if deserializing a request fails

--- a/source/postcard-rpc/src/host_client/util.rs
+++ b/source/postcard-rpc/src/host_client/util.rs
@@ -2,7 +2,7 @@
 use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
 use maitake_sync::WaitQueue;
-use postcard::experimental::schema::Schema;
+use postcard_schema::Schema;
 use serde::de::DeserializeOwned;
 use tokio::{
     select,

--- a/source/postcard-rpc/src/host_client/webusb.rs
+++ b/source/postcard-rpc/src/host_client/webusb.rs
@@ -141,13 +141,14 @@ impl WebUsbWire {
 impl WireTx for WebUsbWire {
     type Error = Error;
 
-    async fn send(&mut self, mut data: Vec<u8>) -> Result<(), Self::Error> {
+    async fn send(&mut self, data: Vec<u8>) -> Result<(), Self::Error> {
         tracing::trace!("send…");
+        let data: js_sys::Uint8Array = data.as_slice().into();
         // TODO for reasons unknown, web-sys wants mutable access to the send buffer.
         // tracking issue: https://github.com/rustwasm/wasm-bindgen/issues/3963
         JsFuture::from(
             self.device
-                .transfer_out_with_u8_array(self.ep_out, &mut data),
+                .transfer_out_with_u8_array(self.ep_out, &data)?,
         )
         .await?;
         Ok(())

--- a/source/postcard-rpc/src/host_client/webusb.rs
+++ b/source/postcard-rpc/src/host_client/webusb.rs
@@ -1,5 +1,5 @@
 use gloo::utils::format::JsValueSerdeExt;
-use postcard::experimental::schema::Schema;
+use postcard_schema::Schema;
 use serde::de::DeserializeOwned;
 use serde_json::json;
 use tracing::info;

--- a/source/postcard-rpc/src/lib.rs
+++ b/source/postcard-rpc/src/lib.rs
@@ -376,10 +376,10 @@ impl Key {
     }
 }
 
-#[cfg(all(feature = "hashv2", feature = "use-std"))]
+#[cfg(feature = "use-std")]
 mod key_owned {
     use super::*;
-    use postcard_schema::schema::OwnedNamedType;
+    use postcard_schema::schema::owned::OwnedNamedType;
     impl Key {
         pub fn for_owned_schema_path(path: &str, nt: &OwnedNamedType) -> Key {
             Key(crate::hash::fnv1a64_owned::hash_ty_path_owned(path, nt))

--- a/source/postcard-rpc/src/lib.rs
+++ b/source/postcard-rpc/src/lib.rs
@@ -439,4 +439,10 @@ pub mod standard_icd {
         UnknownKey([u8; 8]),
         FailedToSpawn,
     }
+
+    #[cfg(not(feature = "use-std"))]
+    crate::topic!(Logging, [u8], "logs/formatted");
+
+    #[cfg(feature = "use-std")]
+    crate::topic!(Logging, Vec<u8>, "logs/formatted");
 }

--- a/source/postcard-rpc/src/lib.rs
+++ b/source/postcard-rpc/src/lib.rs
@@ -401,7 +401,7 @@ pub trait Endpoint {
 /// Typically used with the [topic] macro.
 pub trait Topic {
     /// The type of the Message (unidirectional)
-    type Message: Schema;
+    type Message: Schema + ?Sized;
     /// The path associated with this Topic
     const PATH: &'static str;
     /// The unique [Key] identifying the Message

--- a/source/postcard-rpc/src/lib.rs
+++ b/source/postcard-rpc/src/lib.rs
@@ -40,7 +40,7 @@
 //! # fn main() {}
 //!
 //! use serde::{Serialize, Deserialize};
-//! use postcard::experimental::schema::Schema;
+//! use postcard_schema::Schema;
 //!
 //! #[derive(Serialize, Deserialize, Schema)]
 //! pub struct Alpha {
@@ -85,7 +85,7 @@
 //!
 //! ```rust
 //! # use serde::{Serialize, Deserialize};
-//! # use postcard::experimental::schema::Schema;
+//! # use postcard_schema::Schema;
 //! #
 //! # #[derive(Serialize, Deserialize, Schema)]
 //! # pub struct Alpha {
@@ -135,7 +135,7 @@
 //!
 //! ```rust
 //! # use serde::{Serialize, Deserialize};
-//! # use postcard::experimental::schema::Schema;
+//! # use postcard_schema::Schema;
 //! #
 //! # #[derive(Serialize, Deserialize, Schema)]
 //! # pub struct Delta(pub [u8; 32]);
@@ -175,7 +175,7 @@
 #![cfg_attr(not(any(test, feature = "use-std")), no_std)]
 
 use headered::extract_header_from_bytes;
-use postcard::experimental::schema::Schema;
+use postcard_schema::Schema;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "cobs")]
@@ -379,7 +379,7 @@ impl Key {
 #[cfg(all(feature = "hashv2", feature = "use-std"))]
 mod key_owned {
     use super::*;
-    use postcard::experimental::schema::OwnedNamedType;
+    use postcard_schema::schema::OwnedNamedType;
     impl Key {
         pub fn for_owned_schema_path(path: &str, nt: &OwnedNamedType) -> Key {
             Key(crate::hash::fnv1a64_owned::hash_ty_path_owned(path, nt))
@@ -424,7 +424,7 @@ pub trait Topic {
 /// This is used by [`define_dispatch!()`] as well.
 pub mod standard_icd {
     use crate::Key;
-    use postcard::experimental::schema::Schema;
+    use postcard_schema::Schema;
     use serde::{Deserialize, Serialize};
 
     pub const ERROR_KEY: Key = Key::for_path::<WireError>(ERROR_PATH);

--- a/source/postcard-rpc/src/lib.rs
+++ b/source/postcard-rpc/src/lib.rs
@@ -323,7 +323,7 @@ pub struct WireHeader {
 /// Changing **anything** about *either* of the path or the schema will produce
 /// a drastically different `Key` value.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Deserialize, Hash)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Deserialize, Hash, Schema)]
 pub struct Key([u8; 8]);
 
 impl core::fmt::Debug for Key {
@@ -373,6 +373,17 @@ impl Key {
         }
 
         true
+    }
+}
+
+#[cfg(all(feature = "hashv2", feature = "use-std"))]
+mod key_owned {
+    use super::*;
+    use postcard::experimental::schema::OwnedNamedType;
+    impl Key {
+        pub fn for_owned_schema_path(path: &str, nt: &OwnedNamedType) -> Key {
+            Key(crate::hash::fnv1a64_owned::hash_ty_path_owned(path, nt))
+        }
     }
 }
 

--- a/source/postcard-rpc/src/macros.rs
+++ b/source/postcard-rpc/src/macros.rs
@@ -90,6 +90,9 @@ macro_rules! sender_log {
     ($sender:ident, $($arg:tt)*) => {
         $sender.fmt_publish::<$crate::standard_icd::Logging>(format_args!($($arg)*))
     };
+    ($sender:ident, $s:expr) => {
+        $sender.str_publish::<$crate::standard_icd::Logging>($s)
+    };
     ($($arg:tt)*) => {
         compile_error!("You must pass the sender to `sender_log`!");
     }

--- a/source/postcard-rpc/src/macros.rs
+++ b/source/postcard-rpc/src/macros.rs
@@ -83,3 +83,14 @@ macro_rules! topic {
         }
     };
 }
+
+#[cfg(feature = "embassy-usb-0_3-server")]
+#[macro_export]
+macro_rules! sender_log {
+    ($sender:ident, $($arg:tt)*) => {
+        $sender.fmt_publish::<$crate::standard_icd::Logging>(format_args!($($arg)*))
+    };
+    ($($arg:tt)*) => {
+        compile_error!("You must pass the sender to `sender_log`!");
+    }
+}

--- a/source/postcard-rpc/src/macros.rs
+++ b/source/postcard-rpc/src/macros.rs
@@ -4,7 +4,7 @@
 /// [Endpoint][crate::Endpoint] trait.
 ///
 /// ```rust
-/// # use postcard::experimental::schema::Schema;
+/// # use postcard_schema::Schema;
 /// # use serde::{Serialize, Deserialize};
 /// use postcard_rpc::endpoint;
 ///
@@ -51,7 +51,7 @@ macro_rules! endpoint {
 /// [Topic][crate::Topic] trait.
 ///
 /// ```rust
-/// # use postcard::experimental::schema::Schema;
+/// # use postcard_schema::Schema;
 /// # use serde::{Serialize, Deserialize};
 /// use postcard_rpc::topic;
 ///

--- a/source/postcard-rpc/src/target_server/dispatch_macro.rs
+++ b/source/postcard-rpc/src/target_server/dispatch_macro.rs
@@ -3,7 +3,7 @@
 /// ```rust
 /// # use postcard_rpc::target_server::dispatch_macro::fake::*;
 /// # use postcard_rpc::{endpoint, target_server::{sender::Sender, SpawnContext}, WireHeader, define_dispatch};
-/// # use postcard::experimental::schema::Schema;
+/// # use postcard_schema::Schema;
 /// # use embassy_usb_driver::{Bus, ControlPipe, EndpointIn, EndpointOut};
 /// # use serde::{Deserialize, Serialize};
 ///

--- a/source/postcard-rpc/src/target_server/sender.rs
+++ b/source/postcard-rpc/src/target_server/sender.rs
@@ -1,7 +1,7 @@
 use embassy_sync::{blocking_mutex::raw::RawMutex, mutex::Mutex};
 use embassy_usb_driver::{Driver, Endpoint, EndpointIn};
 use futures_util::FutureExt;
-use postcard::experimental::schema::Schema;
+use postcard_schema::Schema;
 use serde::Serialize;
 use static_cell::StaticCell;
 

--- a/source/postcard-rpc/src/target_server/sender.rs
+++ b/source/postcard-rpc/src/target_server/sender.rs
@@ -25,7 +25,8 @@ impl<M: RawMutex + 'static, D: Driver<'static> + 'static> Sender<M, D> {
         tx_buf: &'static mut [u8],
         ep_in: D::EndpointIn,
     ) -> Self {
-        let x = sc.init(Mutex::new(SenderInner { ep_in, tx_buf }));
+        let max_log_len = actual_varint_max_len(tx_buf.len());
+        let x = sc.init(Mutex::new(SenderInner { ep_in, tx_buf, log_seq: 0, max_log_len }));
         Sender { inner: x }
     }
 
@@ -37,7 +38,7 @@ impl<M: RawMutex + 'static, D: Driver<'static> + 'static> Sender<M, D> {
         E::Response: Serialize + Schema,
     {
         let mut inner = self.inner.lock().await;
-        let SenderInner { ep_in, tx_buf } = &mut *inner;
+        let SenderInner { ep_in, tx_buf, log_seq: _, max_log_len: _ } = &mut *inner;
         if let Ok(used) = crate::headered::to_slice_keyed(seq_no, E::RESP_KEY, resp, tx_buf) {
             send_all::<D>(ep_in, used).await
         } else {
@@ -55,7 +56,7 @@ impl<M: RawMutex + 'static, D: Driver<'static> + 'static> Sender<M, D> {
         T: Serialize + Schema,
     {
         let mut inner = self.inner.lock().await;
-        let SenderInner { ep_in, tx_buf } = &mut *inner;
+        let SenderInner { ep_in, tx_buf, log_seq: _, max_log_len: _ } = &mut *inner;
         if let Ok(used) = crate::headered::to_slice_keyed(seq_no, key, resp, tx_buf) {
             send_all::<D>(ep_in, used).await
         } else {
@@ -71,12 +72,77 @@ impl<M: RawMutex + 'static, D: Driver<'static> + 'static> Sender<M, D> {
         T::Message: Serialize + Schema,
     {
         let mut inner = self.inner.lock().await;
-        let SenderInner { ep_in, tx_buf } = &mut *inner;
+        let SenderInner { ep_in, tx_buf, log_seq: _, max_log_len: _ } = &mut *inner;
         if let Ok(used) = crate::headered::to_slice_keyed(seq_no, T::TOPIC_KEY, msg, tx_buf) {
             send_all::<D>(ep_in, used).await
         } else {
             Err(())
         }
+    }
+
+    pub async fn fmt_publish<'a, T>(&self, args: core::fmt::Arguments<'a>)
+    where
+        T: crate::Topic<Message = [u8]>
+    {
+        let mut inner = self.inner.lock().await;
+        let SenderInner { ep_in, tx_buf, log_seq, max_log_len } = &mut *inner;
+        let ttl_len = tx_buf.len();
+
+        // First, populate the header
+        let hdr = crate::WireHeader { key: T::TOPIC_KEY, seq_no: *log_seq };
+        *log_seq = log_seq.wrapping_add(1);
+        let Ok(hdr_used) = postcard::to_slice(&hdr, tx_buf) else {
+            return;
+        };
+        let hdr_used = hdr_used.len();
+
+        // Then, reserve space for non-canonical length fields
+        // We also set all but the last bytes to be "continuation"
+        // bytes
+        let (_, remaining) = tx_buf.split_at_mut(hdr_used);
+        if remaining.len() < *max_log_len {
+            return;
+        }
+        let (len_field, body) = remaining.split_at_mut(*max_log_len);
+        for b in len_field.iter_mut() {
+            *b = 0x80;
+        }
+        len_field.last_mut().map(|b| *b = 0x00);
+
+        // Then, do the formatting
+        let body_len = body.len();
+        let mut sw = SliceWriter(body);
+        let res = core::fmt::write(&mut sw, args);
+
+        // Calculate the number of bytes used *for formatting*.
+        let remain = sw.0.len();
+        let used = body_len - remain;
+
+        // If we had an error, that's probably because we ran out
+        // of room. If we had an error, AND there is at least three
+        // bytes, then replace those with '.'s like ...
+        if res.is_err() && (body.len() >= 3) {
+            let start = body.len() - 3;
+            body[start..].iter_mut().for_each(|b| *b = b'.');
+        }
+
+        // then go back and fill in the len - we write the len
+        // directly to the reserved bytes, and if we DIDN'T use
+        // the full space, we mark the end of the real length as
+        // a continuation field. This will result in a non-canonical
+        // "extended" length in postcard, and will "spill into" the
+        // bytes we wrote previously above
+        let mut len_bytes = [0u8; varint_max::<usize>()];
+        let len_used = varint_usize(used, &mut len_bytes);
+        if len_used.len() != len_field.len() {
+            len_used.last_mut().map(|b| *b = *b | 0x80);
+        }
+        len_field[..len_used.len()].copy_from_slice(len_used);
+
+        // Calculate the TOTAL amount
+        let act_used = ttl_len - remain;
+
+        let _ = send_all::<D>(ep_in, &tx_buf[..act_used]).await;
     }
 }
 
@@ -90,6 +156,8 @@ impl<M: RawMutex + 'static, D: Driver<'static> + 'static> Clone for Sender<M, D>
 pub struct SenderInner<D: Driver<'static>> {
     ep_in: D::EndpointIn,
     tx_buf: &'static mut [u8],
+    log_seq: u32,
+    max_log_len: usize,
 }
 
 /// Helper function for sending a single frame.
@@ -119,4 +187,75 @@ where
     }
 
     Ok(())
+}
+
+struct SliceWriter<'a>(&'a mut [u8]);
+
+impl<'a> core::fmt::Write for SliceWriter<'a> {
+    fn write_str(&mut self, s: &str) -> Result<(), core::fmt::Error> {
+        let sli = core::mem::take(&mut self.0);
+
+        // If this write would overflow us, note that, but still take
+        // as much as we possibly can here
+        let bad = s.len() > sli.len();
+        let to_write = s.len().min(sli.len());
+        let (now, later) = sli.split_at_mut(to_write);
+        now.copy_from_slice(s.as_bytes());
+        self.0 = later;
+
+        // Now, report whether we overflowed or not
+        if bad {
+            Err(core::fmt::Error)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Returns the maximum number of bytes required to encode T.
+const fn varint_max<T: Sized>() -> usize {
+    const BITS_PER_BYTE: usize = 8;
+    const BITS_PER_VARINT_BYTE: usize = 7;
+
+    // How many data bits do we need for this type?
+    let bits = core::mem::size_of::<T>() * BITS_PER_BYTE;
+
+    // We add (BITS_PER_VARINT_BYTE - 1), to ensure any integer divisions
+    // with a remainder will always add exactly one full byte, but
+    // an evenly divided number of bits will be the same
+    let roundup_bits = bits + (BITS_PER_VARINT_BYTE - 1);
+
+    // Apply division, using normal "round down" integer division
+    roundup_bits / BITS_PER_VARINT_BYTE
+}
+
+#[inline]
+fn varint_usize(n: usize, out: &mut [u8; varint_max::<usize>()]) -> &mut [u8] {
+    let mut value = n;
+    for i in 0..varint_max::<usize>() {
+        out[i] = value.to_le_bytes()[0];
+        if value < 128 {
+            return &mut out[..=i];
+        }
+
+        out[i] |= 0x80;
+        value >>= 7;
+    }
+    debug_assert_eq!(value, 0);
+    &mut out[..]
+}
+
+
+fn actual_varint_max_len(largest: usize) -> usize {
+    if largest < (2 << 7) {
+        1
+    } else if largest < (2 << 14) {
+        2
+    } else if largest < (2 << 21) {
+        3
+    } else if largest < (2 << 28) {
+        4
+    } else {
+        varint_max::<usize>()
+    }
 }

--- a/source/postcard-rpc/src/test_utils.rs
+++ b/source/postcard-rpc/src/test_utils.rs
@@ -8,7 +8,7 @@ use crate::{
     host_client::{HostClient, RpcFrame, WireRx, WireSpawn, WireTx},
     Endpoint, Topic, WireHeader,
 };
-use postcard::experimental::schema::Schema;
+use postcard_schema::Schema;
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::{
     select,


### PR DESCRIPTION
This introduces a new, NOT BACKWARDS COMPATIBLE, version two of the schema hashing algorithm.

This makes two changes:

* We replace the sequential u8 values representing variants of the schema with random 8-bit primes. This is intended to reduce the chance of hash collisions, however to my knowledge hash collisions have never been observed (in the wild or maliciously/intentionally).
* We no longer hash the *name* of a type, as proposed by @zeenix. This allows for potential "type punning" when two types are represented on the wire in the same way. For example, `heapless::String` and `std::string::String` should produce the same schema hash, or `&[u8]` and `Vec<u8>`.

I plan to experiment with this in this PR, and if merged, would be added as a non-default option for the 0.7.x release train. In the future (e.g. 0.8.x), hashv2 would become either the only supported algorithm, or would become the default with an opt-in feature for the legacy v1 hashing.

One thing I plan to look at is if I can relax any `+ 'static`/"Owned" bounds on various traits or methods. The hope would be to allow non-`'static` *sending/serialization*, but still require `'static` bounds for *receiving/deserialization*. This would allow a no-std device to send `&[u8]`, while allowing the std host to receive as a `Vec<u8>`.

I need to write more in depth about this, as it takes the schema system from "strict nominal + strict structural typing" to "strict structural typing + partial nominal typing", where "partial nominal typing" is defined that the names of struct fields and enum variants are still considered, but the names of types themselves are NOT considered.

Closes #23 