### PR TITLE
replace embassy_usb_driver import with re-export from embassy_usb

### DIFF
--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -110,10 +110,6 @@ optional = true
 version = "0.3"
 optional = true
 
-[dependencies.embassy-usb-driver]
-version = "0.1"
-optional = true
-
 [dependencies.embassy-sync]
 version = "0.6"
 optional = true
@@ -187,7 +183,6 @@ embassy-usb-0_3-server = [
     "dep:embassy-usb",
     "dep:embassy-sync",
     "dep:static_cell",
-    "dep:embassy-usb-driver",
     "dep:embassy-executor",
 ]
 

--- a/source/postcard-rpc/src/target_server/mod.rs
+++ b/source/postcard-rpc/src/target_server/mod.rs
@@ -7,11 +7,12 @@ use crate::{
 };
 use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_usb::{
+    driver::{Endpoint, EndpointError, EndpointOut},
     driver::Driver,
     msos::{self, windows_version},
     Builder, UsbDevice,
 };
-use embassy_usb_driver::{Endpoint, EndpointError, EndpointOut};
+
 use sender::Sender;
 
 pub mod buffers;

--- a/source/postcard-rpc/src/target_server/sender.rs
+++ b/source/postcard-rpc/src/target_server/sender.rs
@@ -1,5 +1,5 @@
 use embassy_sync::{blocking_mutex::raw::RawMutex, mutex::Mutex};
-use embassy_usb_driver::{Driver, Endpoint, EndpointIn};
+use embassy_usb::driver::{Driver, Endpoint, EndpointIn};
 use postcard::experimental::schema::Schema;
 use serde::Serialize;
 use static_cell::StaticCell;


### PR DESCRIPTION
Most embassy users use the git version by pathing crates-io. Its easy to forget to patch both embassy-usb and embassy-usb-driver. By relying on embassy-usb-driver as re-exported by embassy-usb that can no longer happen.