### PR TITLE
Update embassy-executor to v0.6

### DIFF
--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -124,7 +124,7 @@ version = "2.1"
 optional = true
 
 [dependencies.embassy-executor]
-version = "0.5"
+version = "0.6.1"
 optional = true
 
 [dependencies.futures-util]


### PR DESCRIPTION
An unsoundness was found in v0.5, it's going to get yanked soon.
