### PR TITLE
USB Composite Device Support

### DIFF
--- a/source/postcard-rpc/src/host_client/raw_nusb.rs
+++ b/source/postcard-rpc/src/host_client/raw_nusb.rs
@@ -85,11 +85,15 @@ where
             .map_err(|e| format!("Error listing devices: {e:?}"))?
             .find(func)
             .ok_or_else(|| String::from("Failed to find matching nusb device!"))?;
+        let interface_id = x
+            .interfaces()
+            .position(|i| i.class() == 0xFF)
+            .ok_or_else(|| String::from("Failed to find matching interface!!"))?;
         let dev = x
             .open()
             .map_err(|e| format!("Failed opening device: {e:?}"))?;
         let interface = dev
-            .claim_interface(0)
+            .claim_interface(interface_id as u8)
             .map_err(|e| format!("Failed claiming interface: {e:?}"))?;
 
         let boq = interface.bulk_out_queue(BULK_OUT_EP);

--- a/source/postcard-rpc/src/host_client/raw_nusb.rs
+++ b/source/postcard-rpc/src/host_client/raw_nusb.rs
@@ -4,7 +4,7 @@ use std::future::Future;
 
 use nusb::{
     transfer::{Queue, RequestBuffer, TransferError},
-    DeviceInfo,
+    DeviceInfo, InterfaceInfo,
 };
 use postcard_schema::Schema;
 use serde::de::DeserializeOwned;
@@ -88,6 +88,85 @@ where
         let interface_id = x
             .interfaces()
             .position(|i| i.class() == 0xFF)
+            .ok_or_else(|| String::from("Failed to find matching interface!!"))?;
+        let dev = x
+            .open()
+            .map_err(|e| format!("Failed opening device: {e:?}"))?;
+        let interface = dev
+            .claim_interface(interface_id as u8)
+            .map_err(|e| format!("Failed claiming interface: {e:?}"))?;
+
+        let boq = interface.bulk_out_queue(BULK_OUT_EP);
+        let biq = interface.bulk_in_queue(BULK_IN_EP);
+
+        Ok(HostClient::new_with_wire(
+            NusbWireTx { boq },
+            NusbWireRx {
+                biq,
+                consecutive_errs: 0,
+            },
+            NusbSpawn,
+            seq_no_kind,
+            err_uri_path,
+            outgoing_depth,
+        ))
+    }
+    /// Try to create a new link using [`nusb`] for connectivity
+    ///
+    /// The provided function will be used to find a matching device. The first
+    /// matching device will be connected to. `err_uri_path` is
+    /// the path associated with the `WireErr` message type.
+    ///
+    /// Returns an error if no device or interface could be found, or if there was an error
+    /// connecting to the device or interface.
+    ///
+    /// This constructor is available when the `raw-nusb` feature is enabled.
+    ///
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// use postcard_rpc::host_client::HostClient;
+    /// use postcard_rpc::header::VarSeqKind;
+    /// use serde::{Serialize, Deserialize};
+    /// use postcard_schema::Schema;
+    ///
+    /// /// A "wire error" type your server can use to respond to any
+    /// /// kind of request, for example if deserializing a request fails
+    /// #[derive(Debug, PartialEq, Schema, Serialize, Deserialize)]
+    /// pub enum Error {
+    ///    SomethingBad
+    /// }
+    ///
+    /// let client = HostClient::<Error>::try_new_raw_nusb_with_interface(
+    ///     // Find the first device with the serial 12345678
+    ///     |d| d.serial_number() == Some("12345678"),
+    ///     // Find the "Vendor Specific" interface
+    ///     |i| i.class() == 0xFF,
+    ///     // the URI/path for `Error` messages
+    ///     "error",
+    ///     // Outgoing queue depth in messages
+    ///     8,
+    ///     // Use one-byte sequence numbers
+    ///     VarSeqKind::Seq1,
+    /// ).unwrap();
+    /// ```
+    pub fn try_new_raw_nusb_with_interface<
+        F1: FnMut(&DeviceInfo) -> bool,
+        F2: FnMut(&InterfaceInfo) -> bool,
+    >(
+        device_func: F1,
+        interface_func: F2,
+        err_uri_path: &str,
+        outgoing_depth: usize,
+        seq_no_kind: VarSeqKind,
+    ) -> Result<Self, String> {
+        let x = nusb::list_devices()
+            .map_err(|e| format!("Error listing devices: {e:?}"))?
+            .find(device_func)
+            .ok_or_else(|| String::from("Failed to find matching nusb device!"))?;
+        let interface_id = x
+            .interfaces()
+            .position(interface_func)
             .ok_or_else(|| String::from("Failed to find matching interface!!"))?;
         let dev = x
             .open()

--- a/source/postcard-rpc/src/host_client/raw_nusb.rs
+++ b/source/postcard-rpc/src/host_client/raw_nusb.rs
@@ -4,7 +4,7 @@ use std::future::Future;
 
 use nusb::{
     transfer::{Queue, RequestBuffer, TransferError},
-    DeviceInfo, InterfaceInfo,
+    DeviceInfo,
 };
 use postcard_schema::Schema;
 use serde::de::DeserializeOwned;
@@ -67,8 +67,6 @@ where
     /// let client = HostClient::<Error>::try_new_raw_nusb(
     ///     // Find the first device with the serial 12345678
     ///     |d| d.serial_number() == Some("12345678"),
-    ///     // Find the "Vendor Specific" interface
-    ///     |i| i.class() == 0xFF,
     ///     // the URI/path for `Error` messages
     ///     "error",
     ///     // Outgoing queue depth in messages
@@ -77,26 +75,21 @@ where
     ///     VarSeqKind::Seq1,
     /// ).unwrap();
     /// ```
-    pub fn try_new_raw_nusb<F1: FnMut(&DeviceInfo) -> bool, F2: FnMut(&InterfaceInfo) -> bool>(
-        device_func: F1,
-        interface_func: F2,
+    pub fn try_new_raw_nusb<F: FnMut(&DeviceInfo) -> bool>(
+        func: F,
         err_uri_path: &str,
         outgoing_depth: usize,
         seq_no_kind: VarSeqKind,
     ) -> Result<Self, String> {
         let x = nusb::list_devices()
             .map_err(|e| format!("Error listing devices: {e:?}"))?
-            .find(device_func)
+            .find(func)
             .ok_or_else(|| String::from("Failed to find matching nusb device!"))?;
-        let interface_id = x
-            .interfaces()
-            .position(interface_func)
-            .ok_or_else(|| String::from("Failed to find matching interface!"))?;
         let dev = x
             .open()
             .map_err(|e| format!("Failed opening device: {e:?}"))?;
         let interface = dev
-            .claim_interface(interface_id as u8)
+            .claim_interface(0)
             .map_err(|e| format!("Failed claiming interface: {e:?}"))?;
 
         let boq = interface.bulk_out_queue(BULK_OUT_EP);
@@ -139,8 +132,6 @@ where
     /// let client = HostClient::<Error>::new_raw_nusb(
     ///     // Find the first device with the serial 12345678
     ///     |d| d.serial_number() == Some("12345678"),
-    ///     // Find the "Vendor Specific" interface
-    ///     |i| i.class() == 0xFF,
     ///     // the URI/path for `Error` messages
     ///     "error",
     ///     // Outgoing queue depth in messages
@@ -149,14 +140,13 @@ where
     ///     VarSeqKind::Seq1,
     /// );
     /// ```
-    pub fn new_raw_nusb<F1: FnMut(&DeviceInfo) -> bool, F2: FnMut(&InterfaceInfo) -> bool>(
-        device: F1,
-        interface: F2,
+    pub fn new_raw_nusb<F: FnMut(&DeviceInfo) -> bool>(
+        func: F,
         err_uri_path: &str,
         outgoing_depth: usize,
         seq_no_kind: VarSeqKind,
     ) -> Self {
-        Self::try_new_raw_nusb(device, interface, err_uri_path, outgoing_depth, seq_no_kind)
+        Self::try_new_raw_nusb(func, err_uri_path, outgoing_depth, seq_no_kind)
             .expect("should have found nusb device")
     }
 }

--- a/source/postcard-rpc/src/server/impls/embassy_usb_v0_3.rs
+++ b/source/postcard-rpc/src/server/impls/embassy_usb_v0_3.rs
@@ -163,7 +163,7 @@ pub mod dispatch_impl {
             driver: D,
             config: Config<'static>,
             tx_buf: &'static mut [u8],
-        ) -> (UsbDevice<'static, D>, WireTxImpl<M, D>, WireRxImpl<D>) {
+        ) -> (Builder<'static, D>, WireTxImpl<M, D>, WireRxImpl<D>) {
             let bufs = self.bufs_usb.take();
 
             let mut builder = Builder::new(
@@ -204,10 +204,7 @@ pub mod dispatch_impl {
                 pending_frame: false,
             }));
 
-            // Build the builder.
-            let usb = builder.build();
-
-            (usb, EUsbWireTx { inner: wtx }, EUsbWireRx { ep_out })
+            (builder, EUsbWireTx { inner: wtx }, EUsbWireRx { ep_out })
         }
     }
 }

--- a/source/postcard-rpc/src/server/impls/embassy_usb_v0_3.rs
+++ b/source/postcard-rpc/src/server/impls/embassy_usb_v0_3.rs
@@ -163,6 +163,19 @@ pub mod dispatch_impl {
             driver: D,
             config: Config<'static>,
             tx_buf: &'static mut [u8],
+        ) -> (UsbDevice<'static, D>, WireTxImpl<M, D>, WireRxImpl<D>) {
+            let (builder, wtx, wrx) = self.init_without_build(driver, config, tx_buf);
+            let usb = builder.build();
+            (usb, wtx, wrx)
+        }
+        /// Initialize the static storage, without building `Builder`
+        ///
+        /// This must only be called once.
+        pub fn init_without_build(
+            &'static self,
+            driver: D,
+            config: Config<'static>,
+            tx_buf: &'static mut [u8],
         ) -> (Builder<'static, D>, WireTxImpl<M, D>, WireRxImpl<D>) {
             let bufs = self.bufs_usb.take();
 


### PR DESCRIPTION
This pull request aims to expand USB functionality by adding support for a composite USB device.

### Motivation

The motivation behind creating a composite USB device is to enable versatile control of my audio device currently under development. In my case:

- USB MIDI Interface: This interface will allow my device to be controlled by DAW software on a host PC, providing integration with standard audio workflows.
- Vendor-Specific Interface (with postcard-rpc support): This secondary interface enables more detailed control of the device via CLI, even if a user does not have a DAW. This addition offers two primary benefits:
    - User Accessibility: Users can control the device using a simple CLI utility, making it accessible even outside of DAW environments.
    - Development & Debugging: From my end, this interface is invaluable for running simple tests from the PC, simplifying debugging during development.

### Details

To implement this, I introduced a closure argument to `new_raw_nusb`, providing flexibility in selecting the interface number from `InterfaceInfo` ([commit ba2ac52](https://github.com/Dicklessgreat/postcard-rpc/commit/ba2ac52741fe835cae0462af1ecec4b622b7c316)). However, I recognize alternative methods might exist, and I'm open to feedback on optimal design approaches.

### Background

As a developer with limited experience in USB standards, I'm aware this approach may not fully align with best practices. If supporting multiple USB classes in a single device proves incompatible with the design goals of this crate, I'm open to revising or abandoning this feature.