### PR TITLE
Relax postcard version dependency

### DIFF
--- a/example/firmware/Cargo.lock
+++ b/example/firmware/Cargo.lock
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "postcard"
-version = "1.1.0"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63d01def49fc815900a83e7a4a5083d2abc81b7ddd569a3fa0477778ae9b3ec"
+checksum = "5f7f0a8d620d71c457dd1d47df76bb18960378da56af4527aaa10f515eee732e"
 dependencies = [
  "cobs",
  "heapless 0.7.17",

--- a/example/firmware/Cargo.toml
+++ b/example/firmware/Cargo.toml
@@ -14,7 +14,7 @@ embedded-hal-bus        = { version = "0.1",   features = ["async"] }
 lis3dh-async            = { version = "0.9.2", features = ["defmt"] }
 panic-probe             = { version = "0.3",   features = ["print-defmt"] }
 postcard-rpc            = { version = "0.11",   features = ["embassy-usb-0_3-server"] }
-postcard                = { version = "1.1.0" }
+postcard                = { version = "1.0.10" }
 postcard-schema         = { version = "0.2.0", features = ["derive"] }
 portable-atomic         = { version = "1.6.0", features = ["critical-section"] }
 

--- a/example/workbook-host/Cargo.lock
+++ b/example/workbook-host/Cargo.lock
@@ -453,9 +453,9 @@ checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "postcard"
-version = "1.1.0"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63d01def49fc815900a83e7a4a5083d2abc81b7ddd569a3fa0477778ae9b3ec"
+checksum = "5f7f0a8d620d71c457dd1d47df76bb18960378da56af4527aaa10f515eee732e"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",

--- a/source/postcard-rpc-test/Cargo.lock
+++ b/source/postcard-rpc-test/Cargo.lock
@@ -346,9 +346,9 @@ checksum = "3bccab0e7fd7cc19f820a1c8c91720af652d0c88dc9664dd72aef2614f04af3b"
 
 [[package]]
 name = "postcard"
-version = "1.1.0"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63d01def49fc815900a83e7a4a5083d2abc81b7ddd569a3fa0477778ae9b3ec"
+checksum = "5f7f0a8d620d71c457dd1d47df76bb18960378da56af4527aaa10f515eee732e"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",

--- a/source/postcard-rpc-test/Cargo.toml
+++ b/source/postcard-rpc-test/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies.postcard]
-version = "1.1.0"
+version = "1.0.10"
 features = ["use-std", "experimental-derive"]
 
 [dependencies.serde]

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -27,7 +27,7 @@ features = [
 cobs = { version = "0.2.3", optional = true, default-features = false }
 defmt = { version = "0.3.5", optional = true }
 heapless = "0.8.0"
-postcard = { version = "1.1.0" }
+postcard = { version = "1.0.10" }
 serde = { version = "1.0.192", default-features = false, features = ["derive"] }
 postcard-schema = { version = "0.2.0", features = ["derive"] }
 


### PR DESCRIPTION
This allows for both 1.0 and 1.1 versions of postcard. This was useful for me when building a project with both older and newer postcard-rpc versions for communication with "legacy" devices that could not be immediately updated.

This will still pick postcard 1.1, unless there is some other dependency that is stuck on a 1.0.x version of postcard.