### PR TITLE
Implement conversion from `VarSeq` and relax equality comparison

### DIFF
--- a/source/postcard-rpc/src/header.rs
+++ b/source/postcard-rpc/src/header.rs
@@ -260,6 +260,36 @@ impl From<u32> for VarSeq {
     }
 }
 
+impl Into<u8> for VarSeq {
+    fn into(self) -> u8 {
+        match self {
+            VarSeq::Seq1(v) => v,
+            VarSeq::Seq2(v) => v as u8,
+            VarSeq::Seq4(v) => v as u8,
+        }
+    }
+}
+
+impl Into<u16> for VarSeq {
+    fn into(self) -> u16 {
+        match self {
+            VarSeq::Seq1(v) => v.into(),
+            VarSeq::Seq2(v) => v,
+            VarSeq::Seq4(v) => v as u16,
+        }
+    }
+}
+
+impl Into<u32> for VarSeq {
+    fn into(self) -> u32 {
+        match self {
+            VarSeq::Seq1(v) => v.into(),
+            VarSeq::Seq2(v) => v.into(),
+            VarSeq::Seq4(v) => v,
+        }
+    }
+}
+
 impl VarSeq {
     /// Resize (up or down) to the requested kind.
     ///

--- a/source/postcard-rpc/src/header.rs
+++ b/source/postcard-rpc/src/header.rs
@@ -663,4 +663,21 @@ mod test {
             assert_eq!(val, &deser);
         }
     }
+
+    #[test]
+    fn var_seq_equality() {
+        let val32 = 0x12345678;
+        let val16 = 0x9abc;
+        let val8 = 0xde;
+
+        assert_eq!(VarSeq::Seq1(val8), VarSeq::Seq1(val8));
+        assert_eq!(VarSeq::Seq1(val8), VarSeq::Seq2(val8.into()));
+        assert_eq!(VarSeq::Seq1(val8), VarSeq::Seq4(val8.into()));
+        assert_ne!(VarSeq::Seq2(val16), VarSeq::Seq1(val16 as u8));
+        assert_eq!(VarSeq::Seq2(val16), VarSeq::Seq2(val16));
+        assert_eq!(VarSeq::Seq2(val16), VarSeq::Seq4(val16.into()));
+        assert_ne!(VarSeq::Seq4(val32), VarSeq::Seq1(val32 as u8));
+        assert_ne!(VarSeq::Seq4(val32), VarSeq::Seq2(val32 as u16));
+        assert_eq!(VarSeq::Seq4(val32), VarSeq::Seq4(val32));
+    }
 }

--- a/source/postcard-rpc/src/header.rs
+++ b/source/postcard-rpc/src/header.rs
@@ -232,7 +232,7 @@ pub enum VarKeyKind {
 ///
 /// We DO NOT impl Serialize/Deserialize for this type because we use
 /// non-postcard-compatible format (externally tagged)
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum VarSeq {
     /// A one byte sequence number
     Seq1(u8),
@@ -287,6 +287,12 @@ impl Into<u32> for VarSeq {
             VarSeq::Seq2(v) => v.into(),
             VarSeq::Seq4(v) => v,
         }
+    }
+}
+
+impl PartialEq for VarSeq {
+    fn eq(&self, other: &Self) -> bool {
+        Into::<u32>::into(*self) == Into::<u32>::into(*other)
     }
 }
 


### PR DESCRIPTION
As I am sending sequence numbers around to reference it in other operations I extended `VarSeq` a bit. I implemented conversion into `u8`, `u16` and `u32`.
This also adds a manual implementation of `PartialEq` to treat different variants with the same key value as equal. Previously `VarSeq::Seq1(1) != VarSeq::Seq2(1)`, with this change they are treated as equal. For me this is the correct way to handle it, as the value is the important part, the variants are only to save bytes where possible. This might however be different to how the library expects it.

