### PR TITLE
Use `path` instead of `ident` in `dispatch_impl!`

### DIFF
--- a/source/postcard-rpc-test/tests/basic.rs
+++ b/source/postcard-rpc-test/tests/basic.rs
@@ -14,7 +14,9 @@ use postcard_rpc::{
     host_client::{test_channels as client, HostClient},
     server::{
         impls::test_channels::{
-            dispatch_impl::{new_server, new_server_stoppable, spawn_fn, Settings, WireSpawnImpl, WireTxImpl},
+            dispatch_impl::{
+                new_server, new_server_stoppable, spawn_fn, Settings, WireSpawnImpl, WireTxImpl,
+            },
             ChannelWireRx, ChannelWireSpawn, ChannelWireTx,
         },
         Dispatch, Sender, SpawnContext,
@@ -130,7 +132,7 @@ define_dispatch! {
     context: TestContext;
 
     endpoints: {
-        list: ENDPOINT_LIST;
+        list: crate::ENDPOINT_LIST;
 
         | EndpointTy        | kind      | handler                   |
         | ----------        | ----      | -------                   |
@@ -140,7 +142,7 @@ define_dispatch! {
         | BorrowEndpoint2   | blocking  | test_borrowep_blocking2   |
     };
     topics_in: {
-        list: TOPICS_IN_LIST;
+        list: crate::TOPICS_IN_LIST;
 
         | TopicTy           | kind      | handler               |
         | ----------        | ----      | -------               |
@@ -600,7 +602,7 @@ async fn end_to_end_stoppable() {
     assert_eq!(resp.0, 42);
     stopper.stop();
     match timeout(Duration::from_millis(100), hdl).await {
-        Ok(Ok(())) => {},
+        Ok(Ok(())) => {}
         Ok(Err(e)) => panic!("Server task panicked? {e:?}"),
         Err(_) => panic!("Server task did not stop!"),
     }

--- a/source/postcard-rpc/src/server/dispatch_macro.rs
+++ b/source/postcard-rpc/src/server/dispatch_macro.rs
@@ -225,21 +225,21 @@ macro_rules! define_dispatch {
         context: $context_ty:ty;
 
         endpoints: {
-            list: $endpoint_list:ident;
+            list: $endpoint_list:path;
 
                | EndpointTy     | kind          | handler           |
                | $(-)*          | $(-)*         | $(-)*             |
-            $( | $endpoint:ty   | $ep_flavor:tt | $ep_handler:ident | )*
+            $( | $endpoint:ty   | $ep_flavor:tt | $ep_handler:ident  | )*
         };
         topics_in: {
-            list: $topic_in_list:ident;
+            list: $topic_in_list:path;
 
                | TopicTy        | kind          | handler           |
                | $(-)*          | $(-)*         | $(-)*             |
-            $( | $topic_in:ty   | $tp_flavor:tt | $tp_handler:ident | )*
+            $( | $topic_in:ty   | $tp_flavor:tt | $tp_handler:ident  | )*
         };
         topics_out: {
-            list: $topic_out_list:ident;
+            list: $topic_out_list:path;
         };
     ) => {
 


### PR DESCRIPTION
This allows the `dispatch_impl!` macro to accept not only identifiers, but also fully qualified paths which refer to either a list of endpoints, incoming topics, or outgoing topics.