### PR TITLE
Suppress warnings when the client has been stopped

### DIFF
--- a/source/postcard-rpc/src/host_client/util.rs
+++ b/source/postcard-rpc/src/host_client/util.rs
@@ -115,6 +115,7 @@ where
     let cancel_fut = stop.wait_stopped();
     let operate_fut = out_worker_inner(wire, rec);
     select! {
+        biased;
         _ = cancel_fut => {},
         _ = operate_fut => {
             // if WE exited, notify everyone else it's stoppin time
@@ -153,6 +154,7 @@ async fn in_worker<W>(
     let cancel_fut = stop.wait_stopped();
     let operate_fut = in_worker_inner(wire, host_ctx, subscriptions.clone());
     select! {
+        biased;
         _ = cancel_fut => {},
         _ = operate_fut => {
             // if WE exited, notify everyone else it's stoppin time


### PR DESCRIPTION
When the client is dropped, tokio can poll the `select!`-ed futures in a random order, and the client implementation can emit warnings if the WireRx, or the internal receiver are polled before the stopper is.

This PR ensures the cancel future is polled first, which doesn't let the streams run into errors if the client is `stop`ped before dropping it.