### PR TITLE
Undeprecate solo subscribers, implement backpressure with timeout

### DIFF
--- a/source/postcard-rpc/src/host_client/mod.rs
+++ b/source/postcard-rpc/src/host_client/mod.rs
@@ -542,10 +542,12 @@ where
                 .iter_mut()
                 .find(|(k, _)| *k == T::TOPIC_KEY)
             {
-                if !replace_existing {
-                    return Err(SubscribeError::AlreadySubscribed);
+                if !entry.1.is_closed() {
+                    if !replace_existing {
+                        return Err(SubscribeError::AlreadySubscribed);
+                    }
+                    tracing::warn!("replacing subscription for topic path '{}'", T::PATH);
                 }
-                tracing::warn!("replacing subscription for topic path '{}'", T::PATH);
                 entry.1 = tx;
             } else {
                 guard.exclusive_list.push((T::TOPIC_KEY, tx));
@@ -607,10 +609,12 @@ where
                 return Err(SubscribeError::IoClosed);
             }
             if let Some(entry) = guard.exclusive_list.iter_mut().find(|(k, _)| *k == key) {
-                if !replace_existing {
-                    return Err(SubscribeError::AlreadySubscribed);
+                if !entry.1.is_closed() {
+                    if !replace_existing {
+                        return Err(SubscribeError::AlreadySubscribed);
+                    }
+                    tracing::warn!("replacing subscription for raw topic key '{:?}'", key);
                 }
-                tracing::warn!("replacing subscription for raw topic key '{:?}'", key);
                 entry.1 = tx;
             } else {
                 guard.exclusive_list.push((key, tx));

--- a/source/postcard-rpc/src/host_client/mod.rs
+++ b/source/postcard-rpc/src/host_client/mod.rs
@@ -194,6 +194,7 @@ where
             kkind: RwLock::new(VarKeyKind::Key8),
             map: WaitMap::new(),
             seq: AtomicU32::new(0),
+            subscription_timeout: config.subscriber_timeout_if_full,
         });
 
         let err_key = Key::for_path::<WireErr>(config.err_uri_path);
@@ -819,6 +820,7 @@ pub struct HostContext {
     kkind: RwLock<VarKeyKind>,
     map: WaitMap<VarHeader, (VarHeader, Vec<u8>)>,
     seq: AtomicU32,
+    subscription_timeout: Duration,
 }
 
 /// The I/O worker has closed.


### PR DESCRIPTION
The PR should implement everything needed to try a bit harder to not drop incoming (from the server) topic messages.