### PR TITLE
Detect max packet size, and emit zlp if a multiple of that

### DIFF
--- a/source/postcard-rpc/src/server/impls/embassy_usb_v0_3.rs
+++ b/source/postcard-rpc/src/server/impls/embassy_usb_v0_3.rs
@@ -22,7 +22,11 @@ static STINDX: AtomicU8 = AtomicU8::new(0xFF);
 static HDLR: ConstStaticCell<PoststationHandler> = ConstStaticCell::new(PoststationHandler {});
 
 impl embassy_usb_0_3::Handler for PoststationHandler {
-    fn get_string(&mut self, index: embassy_usb_0_3::types::StringIndex, lang_id: u16) -> Option<&str> {
+    fn get_string(
+        &mut self,
+        index: embassy_usb_0_3::types::StringIndex,
+        lang_id: u16,
+    ) -> Option<&str> {
         use embassy_usb_0_3::descriptor::lang_id;
 
         let stindx = STINDX.load(Ordering::Relaxed);

--- a/source/postcard-rpc/src/server/impls/embassy_usb_v0_4.rs
+++ b/source/postcard-rpc/src/server/impls/embassy_usb_v0_4.rs
@@ -22,7 +22,11 @@ static STINDX: AtomicU8 = AtomicU8::new(0xFF);
 static HDLR: ConstStaticCell<PoststationHandler> = ConstStaticCell::new(PoststationHandler {});
 
 impl embassy_usb_0_4::Handler for PoststationHandler {
-    fn get_string(&mut self, index: embassy_usb_0_4::types::StringIndex, lang_id: u16) -> Option<&str> {
+    fn get_string(
+        &mut self,
+        index: embassy_usb_0_4::types::StringIndex,
+        lang_id: u16,
+    ) -> Option<&str> {
         use embassy_usb_0_4::descriptor::lang_id;
 
         let stindx = STINDX.load(Ordering::Relaxed);


### PR DESCRIPTION
This fixes an issue where if the HOST sends a packet that is a multiple of the max packet size, nusb does NOT automatically send a ZLP (like I assumed it did).

We now detect the max packet size, and manually emit a ZLP when necessary.