### PR TITLE
Wait for connection to start the Server transaction loop

### DIFF
--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -19,6 +19,7 @@ features = [
     "cobs-serial",
     "raw-nusb",
     "embassy-usb-0_3-server",
+    "embassy-usb-0_4-server",
     "_docs-fix",
     # TODO: What to do about the webusb feature? Can we do separate target builds?
 ]

--- a/source/postcard-rpc/src/server/impls/embassy_usb_v0_3.rs
+++ b/source/postcard-rpc/src/server/impls/embassy_usb_v0_3.rs
@@ -12,7 +12,7 @@ use embassy_executor::{SpawnError, SpawnToken, Spawner};
 use embassy_futures::select::{select, Either};
 use embassy_sync::{blocking_mutex::raw::RawMutex, mutex::Mutex};
 use embassy_time::Timer;
-use embassy_usb_driver::{Driver, EndpointError, EndpointIn, EndpointOut};
+use embassy_usb_driver::{Driver, Endpoint, EndpointError, EndpointIn, EndpointOut};
 use serde::Serialize;
 use static_cell::ConstStaticCell;
 
@@ -252,6 +252,11 @@ impl<M: RawMutex + 'static, D: Driver<'static> + 'static> Clone for EUsbWireTx<M
 
 impl<M: RawMutex + 'static, D: Driver<'static> + 'static> WireTx for EUsbWireTx<M, D> {
     type Error = WireTxErrorKind;
+
+    async fn wait_connection(&self) {
+        let mut inner = self.inner.lock().await;
+        inner.ep_in.wait_enabled().await;
+    }
 
     async fn send<T: Serialize + ?Sized>(
         &self,
@@ -539,6 +544,10 @@ pub struct EUsbWireRx<D: Driver<'static>> {
 
 impl<D: Driver<'static>> WireRx for EUsbWireRx<D> {
     type Error = WireRxErrorKind;
+
+    async fn wait_connection(&mut self) {
+        self.ep_out.wait_enabled().await;
+    }
 
     async fn receive<'a>(&mut self, buf: &'a mut [u8]) -> Result<&'a mut [u8], Self::Error> {
         let buflen = buf.len();

--- a/source/postcard-rpc/src/server/impls/embassy_usb_v0_4.rs
+++ b/source/postcard-rpc/src/server/impls/embassy_usb_v0_4.rs
@@ -246,7 +246,7 @@ pub struct EUsbWireTxInner<D: Driver<'static>> {
     timeout_ms_per_frame: usize,
 }
 
-/// A [`WireTx`] implementation for embassy-usb 0.3.
+/// A [`WireTx`] implementation for embassy-usb 0.4.
 #[derive(Copy)]
 pub struct EUsbWireTx<M: RawMutex + 'static, D: Driver<'static> + 'static> {
     inner: &'static Mutex<M, EUsbWireTxInner<D>>,
@@ -585,7 +585,7 @@ fn actual_varint_max_len(largest: usize) -> usize {
 // RX
 //////////////////////////////////////////////////////////////////////////////
 
-/// A [`WireRx`] implementation for embassy-usb 0.3.
+/// A [`WireRx`] implementation for embassy-usb 0.4.
 pub struct EUsbWireRx<D: Driver<'static>> {
     ep_out: D::EndpointOut,
 }


### PR DESCRIPTION
Ensure connections are ready before trying to send/receive on them. At least on stm32 this avoids a livelock when calling Server::run in a tight loop.

Only implemented for embassy_usb_v0.4. Happy to implement it for other impls as well if this seems the right direction