### PR TITLE
Let raw-nusb dynamically determine the EPs to use

### DIFF
--- a/example/workbook-host/Cargo.lock
+++ b/example/workbook-host/Cargo.lock
@@ -383,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "nusb"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dccb3bb9c89ba9393f2f723da29221a39a3310c3950fbe5896eec05daa82753e"
+checksum = "2d8beeee5c0ad012e1eaca540f5610d09a3af58ec435537d511b67e0be36ea66"
 dependencies = [
  "atomic-waker",
  "core-foundation",

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -36,7 +36,7 @@ postcard-schema = { version = "0.2.1", features = ["derive"] }
 #
 
 [dependencies.nusb]
-version = "0.1"
+version = "0.1.9"
 optional = true
 
 [dependencies.tokio-serial]


### PR DESCRIPTION
Determine the EPs to use based on the interface descriptors isntead of hard-coding them; On my stm32 the EP's used ended up being 0x1 and 0x82, rather then 0x1 and 0x81 causing postcard-rpc to fail. This should also help in case multiple interfaces are used (where the EPs might not simply be the first ones)