### PR TITLE
feat: ariel-os example initial

### DIFF
--- a/example/firmware-ariel-os/Cargo.toml
+++ b/example/firmware-ariel-os/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "workbook-fw-ariel-os"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ariel-os = { path = "build/imports/ariel-os/src/ariel-os", features = [
+  "override-usb-config",
+] }
+ariel-os-boards = { path = "build/imports/ariel-os/src/ariel-os-boards" }
+embassy-sync = { version = "0.6.1", default-features = false }
+
+postcard-rpc = { version = "0.11", features = ["embassy-usb-0_4-server"] }
+postcard = { version = "1.0.10" }
+postcard-schema = { version = "0.2.1", features = ["derive"] }
+
+workbook-icd = { path = "../workbook-icd" }
+static_cell = "2.1.0"
+
+[patch.crates-io]
+postcard-rpc = { path = "../../source/postcard-rpc" }

--- a/example/firmware-ariel-os/laze-project.yml
+++ b/example/firmware-ariel-os/laze-project.yml
@@ -1,0 +1,11 @@
+imports:
+  - git:
+      url: https://github.com/ariel-os/ariel-os
+      commit: 4a1cf6786da07cc63154c5ddfd26b1487b285f7b
+    dldir: ariel-os
+
+apps:
+  - name: workbook-firmware-ariel-os
+    context: nrf52840dk
+    selects:
+      - usb

--- a/example/firmware-ariel-os/rust-toolchain.toml
+++ b/example/firmware-ariel-os/rust-toolchain.toml
@@ -1,0 +1,14 @@
+# this file is parsed with grep & sed for parsing out the actual toolchain
+# from the "channel" line. Please keep that in mind when modifying.
+[toolchain]
+channel = "nightly-2025-02-25"
+targets = [
+  "thumbv6m-none-eabi",
+  "thumbv7m-none-eabi",
+  "thumbv7em-none-eabi",
+  "thumbv7em-none-eabihf",
+  "thumbv8m.main-none-eabi",
+  "riscv32imc-unknown-none-elf",
+  "riscv32imac-unknown-none-elf",
+]
+components = ["rust-src"]

--- a/example/firmware-ariel-os/src/main.rs
+++ b/example/firmware-ariel-os/src/main.rs
@@ -1,0 +1,120 @@
+#![no_std]
+#![no_main]
+#![feature(impl_trait_in_assoc_type)]
+#![feature(used_with_arg)]
+
+use ariel_os::{asynch::Spawner, debug::log::info, reexports::embassy_usb, usb};
+
+use postcard_rpc::{
+    define_dispatch,
+    header::VarHeader,
+    server::{
+        impls::embassy_usb_v0_4::{
+            dispatch_impl::{WireRxBuf, WireRxImpl, WireSpawnImpl, WireStorage, WireTxImpl},
+            PacketBuffers,
+        },
+        Dispatch, Server,
+    },
+};
+use static_cell::ConstStaticCell;
+use workbook_icd::{PingEndpoint, ENDPOINT_LIST, TOPICS_IN_LIST, TOPICS_OUT_LIST};
+
+pub struct Context;
+
+type AppMutex = embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+type AppDriver = usb::UsbDriver;
+type AppStorage = WireStorage<AppMutex, AppDriver, 256, 256, 64, 256>;
+type BufStorage = PacketBuffers<1024, 1024>;
+type AppTx = WireTxImpl<AppMutex, AppDriver>;
+type AppRx = WireRxImpl<AppDriver>;
+type AppServer = Server<AppTx, AppRx, WireRxBuf, MyApp>;
+
+static PBUFS: ConstStaticCell<BufStorage> = ConstStaticCell::new(BufStorage::new());
+static STORAGE: AppStorage = AppStorage::new();
+
+/// Helper to get unique ID from flash
+pub fn get_unique_id() -> Option<u64> {
+    // TODO
+    Some(0)
+}
+
+#[ariel_os::config(usb)]
+const USB_CONFIG: embassy_usb::Config = {
+    let mut config = embassy_usb::Config::new(0x16c0, 0x27DD);
+    config.manufacturer = Some("OneVariable");
+    config.product = Some("ov-twin");
+    config.serial_number = Some("12345678");
+
+    // Required for windows compatibility.
+    // https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/kconfig/CONFIG_CDC_ACM_IAD.html#help
+    config.device_class = 0xEF;
+    config.device_sub_class = 0x02;
+    config.device_protocol = 0x01;
+    config.composite_with_iads = true;
+
+    config
+};
+
+define_dispatch! {
+    app: MyApp;
+    spawn_fn: spawn_fn;
+    tx_impl: AppTx;
+    spawn_impl: WireSpawnImpl;
+    context: Context;
+
+    endpoints: {
+        list: ENDPOINT_LIST;
+
+        | EndpointTy                | kind      | handler                       |
+        | ----------                | ----      | -------                       |
+        | PingEndpoint              | blocking  | ping_handler                  |
+    };
+    topics_in: {
+        list: TOPICS_IN_LIST;
+
+        | TopicTy                   | kind      | handler                       |
+        | ----------                | ----      | -------                       |
+    };
+    topics_out: {
+        list: TOPICS_OUT_LIST;
+    };
+}
+
+#[ariel_os::task(autostart, usb_builder_hook)]
+async fn main() {
+    info!("Postcard-rpc task starting");
+
+    let unique_id = get_unique_id().unwrap();
+    info!("id: {=u64:016X}", unique_id);
+
+    let context = Context;
+    let pbufs = PBUFS.take();
+
+    // Create and inject the Postcard usb endpoint on the system USB builder.
+    let (tx_impl, rx_impl) = USB_BUILDER_HOOK.with(|builder| {
+        // TODO: init here passing builder
+        STORAGE.init_on_builder(pbufs.tx_buf.as_mut_slice())
+    });
+
+    let spawner = Spawner::for_current_executor().await;
+    let dispatcher = MyApp::new(context, spawner.into());
+    let vkk = dispatcher.min_key_len();
+    let mut server: AppServer = Server::new(
+        tx_impl,
+        rx_impl,
+        pbufs.rx_buf.as_mut_slice(),
+        dispatcher,
+        vkk,
+    );
+
+    loop {
+        // If the host disconnects, we'll return an error here.
+        // If this happens, just wait until the host reconnects
+        let _ = server.run().await;
+    }
+}
+
+fn ping_handler(_context: &mut Context, _header: VarHeader, rqst: u32) -> u32 {
+    info!("ping");
+    rqst
+}


### PR DESCRIPTION
This adds an example based on Ariel OS.

Currently WIP, as Ariel likes to keep control of the usb builder, as does postcard-rpc. Ownership conflict.