### PR TITLE
`define_dispatch`: add docs for app `type`

### DIFF
--- a/example/firmware/src/bin/minimal.rs
+++ b/example/firmware/src/bin/minimal.rs
@@ -1,5 +1,9 @@
+//! This gives a minimal example for a postcard-rpc project.
+
 #![no_std]
 #![no_main]
+
+#![deny(missing_docs)]
 
 use defmt::info;
 use embassy_executor::Spawner;
@@ -21,6 +25,7 @@ use workbook_fw::Irqs;
 use workbook_icd::{ENDPOINT_LIST, TOPICS_IN_LIST, TOPICS_OUT_LIST};
 use {defmt_rtt as _, panic_probe as _};
 
+/// Context shared between the different postcard-rpc functions.
 pub struct Context {}
 
 type AppDriver = usb::Driver<'static, USB>;
@@ -100,6 +105,7 @@ async fn main(spawner: Spawner) {
     spawner.must_spawn(server_task(server));
 }
 
+/// Run the postcard-rpc server forever.
 #[embassy_executor::task]
 pub async fn server_task(mut server: AppServer) {
     loop {

--- a/source/postcard-rpc/src/server/dispatch_macro.rs
+++ b/source/postcard-rpc/src/server/dispatch_macro.rs
@@ -387,6 +387,7 @@ macro_rules! define_dispatch {
         // This is overly complicated because I'm mixing const-time capabilities with
         // macro-time capabilities. I'm very open to other suggestions that achieve the
         // same outcome.
+        #[doc=concat!("This defines the postcard-rpc app implementation for ", stringify!($app_name))]
         pub type $app_name = impls::$app_name<{ sizer::NEEDED_SZ }>;
 
         mod impls {


### PR DESCRIPTION
since the `type` generated for the app is marked as `pub` this triggers the `missing_docs` lint (if enabled) and thus prevents `#![deny(missing_docs)]` from being used in any firmware which uses `postcard-rpc`.
by generating this doc comment we now make the lint happy.

the alternative would have been to add `#[doc(hidden)]`, however there's no reason to hide it and it has been present in the docs so far.

note that macro variables are not replaced in normal doc comments (written using `///`), however these anyway get converted to `#[doc="..."]`, thus we can make use of that. the idea for that came from SO: https://stackoverflow.com/a/78426606

the `minimal` example has been modified to include `#[deny(missing_docs)]` so as to ensure that no future modification will break this again.

resolves #106