### PR TITLE
add `postcard` & `postcard-rpc` re-exports for macros

### DIFF
--- a/example/firmware/Cargo.lock
+++ b/example/firmware/Cargo.lock
@@ -1829,7 +1829,6 @@ dependencies = [
  "pio",
  "pio-proc",
  "portable-atomic",
- "postcard",
  "postcard-rpc",
  "smart-leds",
  "static_cell",

--- a/example/firmware/Cargo.lock
+++ b/example/firmware/Cargo.lock
@@ -1831,7 +1831,6 @@ dependencies = [
  "portable-atomic",
  "postcard",
  "postcard-rpc",
- "postcard-schema",
  "smart-leds",
  "static_cell",
  "workbook-icd",

--- a/example/firmware/Cargo.toml
+++ b/example/firmware/Cargo.toml
@@ -15,7 +15,6 @@ lis3dh-async            = { version = "0.9.2", features = ["defmt"] }
 panic-probe             = { version = "0.3",   features = ["print-defmt"] }
 postcard-rpc            = { version = "0.11",   features = ["embassy-usb-0_4-server"] }
 postcard                = { version = "1.0.10" }
-postcard-schema         = { version = "0.2.1", features = ["derive"] }
 portable-atomic         = { version = "1.6.0", features = ["critical-section"] }
 
 workbook-icd            = { path = "../workbook-icd" }

--- a/example/firmware/Cargo.toml
+++ b/example/firmware/Cargo.toml
@@ -14,7 +14,6 @@ embedded-hal-bus        = { version = "0.1",   features = ["async"] }
 lis3dh-async            = { version = "0.9.2", features = ["defmt"] }
 panic-probe             = { version = "0.3",   features = ["print-defmt"] }
 postcard-rpc            = { version = "0.11",   features = ["embassy-usb-0_4-server"] }
-postcard                = { version = "1.0.10" }
 portable-atomic         = { version = "1.6.0", features = ["critical-section"] }
 
 workbook-icd            = { path = "../workbook-icd" }

--- a/example/workbook-host/Cargo.lock
+++ b/example/workbook-host/Cargo.lock
@@ -1039,7 +1039,6 @@ name = "workbook-host-client"
 version = "0.1.0"
 dependencies = [
  "postcard-rpc",
- "postcard-schema",
  "tokio",
  "workbook-icd",
 ]

--- a/example/workbook-host/Cargo.toml
+++ b/example/workbook-host/Cargo.toml
@@ -14,10 +14,6 @@ features = [
     "raw-nusb",
 ]
 
-[dependencies.postcard-schema]
-version = "0.2.1"
-features = ["derive"]
-
 [dependencies.tokio]
 version = "1.37.0"
 features = [

--- a/source/postcard-rpc/src/lib.rs
+++ b/source/postcard-rpc/src/lib.rs
@@ -115,6 +115,10 @@
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
+/// Re-export used by macros
+#[doc(hidden)]
+pub use postcard_schema;
+
 use header::{VarKey, VarKeyKind};
 use postcard_schema::{schema::NamedType, Schema};
 use serde::{Deserialize, Serialize};

--- a/source/postcard-rpc/src/lib.rs
+++ b/source/postcard-rpc/src/lib.rs
@@ -117,6 +117,9 @@
 
 /// Re-export used by macros
 #[doc(hidden)]
+pub use postcard;
+/// Re-export used by macros
+#[doc(hidden)]
 pub use postcard_schema;
 
 use header::{VarKey, VarKeyKind};

--- a/source/postcard-rpc/src/macros.rs
+++ b/source/postcard-rpc/src/macros.rs
@@ -96,7 +96,7 @@ macro_rules! endpoints {
     };
     (@ep_tys omit_std=true; $([[$($meta:meta)?] $ep_name:ident])*) => {
         const {
-            const LISTS: &[&[&'static postcard_schema::schema::NamedType]] = &[
+            const LISTS: &[&[&'static $crate::postcard_schema::schema::NamedType]] = &[
                 $(
                     $(#[$meta])?
                     $crate::unique_types!(<$ep_name as $crate::Endpoint>::Request),
@@ -106,24 +106,24 @@ macro_rules! endpoints {
             ];
 
             const TTL_COUNT: usize = $crate::uniques::total_len(LISTS);
-            const BIG_RPT: ([Option<&'static postcard_schema::schema::NamedType>; TTL_COUNT], usize) = $crate::uniques::merge_nty_lists(LISTS);
-            const SMALL_RPT: [&'static postcard_schema::schema::NamedType; BIG_RPT.1] = $crate::uniques::cruncher(BIG_RPT.0.as_slice());
+            const BIG_RPT: ([Option<&'static $crate::postcard_schema::schema::NamedType>; TTL_COUNT], usize) = $crate::uniques::merge_nty_lists(LISTS);
+            const SMALL_RPT: [&'static $crate::postcard_schema::schema::NamedType; BIG_RPT.1] = $crate::uniques::cruncher(BIG_RPT.0.as_slice());
             SMALL_RPT.as_slice()
         }
     };
     (@ep_tys omit_std=false; $([[$($meta:meta)?] $ep_name:ident])*) => {
         const {
-            const USER_TYS: &[&'static postcard_schema::schema::NamedType] =
+            const USER_TYS: &[&'static $crate::postcard_schema::schema::NamedType] =
                 $crate::endpoints!(@ep_tys omit_std=true; $([[$($meta)?] $ep_name])*);
-            const STD_TYS: &[&'static postcard_schema::schema::NamedType]
+            const STD_TYS: &[&'static $crate::postcard_schema::schema::NamedType]
                 = $crate::standard_icd::STANDARD_ICD_ENDPOINTS.types;
 
-            const BOTH: &[&[&'static postcard_schema::schema::NamedType]] = &[
+            const BOTH: &[&[&'static $crate::postcard_schema::schema::NamedType]] = &[
                 USER_TYS, STD_TYS,
             ];
             const TTL_COUNT: usize = $crate::uniques::total_len(BOTH);
-            const BIG_RPT: ([Option<&'static postcard_schema::schema::NamedType>; TTL_COUNT], usize) = $crate::uniques::merge_nty_lists(BOTH);
-            const SMALL_RPT: [&'static postcard_schema::schema::NamedType; BIG_RPT.1] = $crate::uniques::cruncher(BIG_RPT.0.as_slice());
+            const BIG_RPT: ([Option<&'static $crate::postcard_schema::schema::NamedType>; TTL_COUNT], usize) = $crate::uniques::merge_nty_lists(BOTH);
+            const SMALL_RPT: [&'static $crate::postcard_schema::schema::NamedType; BIG_RPT.1] = $crate::uniques::cruncher(BIG_RPT.0.as_slice());
             SMALL_RPT.as_slice()
         }
     };
@@ -279,7 +279,7 @@ macro_rules! topics {
     };
     (@tp_tys ( $dir:expr ) omit_std=true; $([[$($meta:meta)?] $tp_name:ident])*) => {
         const {
-            const LISTS: &[&[&'static postcard_schema::schema::NamedType]] = &[
+            const LISTS: &[&[&'static $crate::postcard_schema::schema::NamedType]] = &[
                 $(
                     $(#[$meta])?
                     $crate::unique_types!(<$tp_name as $crate::Topic>::Message),
@@ -287,28 +287,28 @@ macro_rules! topics {
             ];
 
             const TTL_COUNT: usize = $crate::uniques::total_len(LISTS);
-            const BIG_RPT: ([Option<&'static postcard_schema::schema::NamedType>; TTL_COUNT], usize) = $crate::uniques::merge_nty_lists(LISTS);
-            const SMALL_RPT: [&'static postcard_schema::schema::NamedType; BIG_RPT.1] = $crate::uniques::cruncher(BIG_RPT.0.as_slice());
+            const BIG_RPT: ([Option<&'static $crate::postcard_schema::schema::NamedType>; TTL_COUNT], usize) = $crate::uniques::merge_nty_lists(LISTS);
+            const SMALL_RPT: [&'static $crate::postcard_schema::schema::NamedType; BIG_RPT.1] = $crate::uniques::cruncher(BIG_RPT.0.as_slice());
             SMALL_RPT.as_slice()
         }
     };
     (@tp_tys ( $dir:expr ) omit_std=false; $([[$($meta:meta)?] $tp_name:ident])*) => {
         const {
-            const USER_TYS: &[&'static postcard_schema::schema::NamedType] =
+            const USER_TYS: &[&'static $crate::postcard_schema::schema::NamedType] =
                 $crate::topics!(@tp_tys ( $dir ) omit_std=true; $([[$($meta)?] $tp_name])*);
-            const STD_TYS: &[&'static postcard_schema::schema::NamedType] = const {
+            const STD_TYS: &[&'static $crate::postcard_schema::schema::NamedType] = const {
                 match $dir {
                     $crate::TopicDirection::ToServer => $crate::standard_icd::STANDARD_ICD_TOPICS_IN.types,
                     $crate::TopicDirection::ToClient => $crate::standard_icd::STANDARD_ICD_TOPICS_OUT.types,
                 }
             };
 
-            const BOTH: &[&[&'static postcard_schema::schema::NamedType]] = &[
+            const BOTH: &[&[&'static $crate::postcard_schema::schema::NamedType]] = &[
                 STD_TYS, USER_TYS,
             ];
             const TTL_COUNT: usize = $crate::uniques::total_len(BOTH);
-            const BIG_RPT: ([Option<&'static postcard_schema::schema::NamedType>; TTL_COUNT], usize) = $crate::uniques::merge_nty_lists(BOTH);
-            const SMALL_RPT: [&'static postcard_schema::schema::NamedType; BIG_RPT.1] = $crate::uniques::cruncher(BIG_RPT.0.as_slice());
+            const BIG_RPT: ([Option<&'static $crate::postcard_schema::schema::NamedType>; TTL_COUNT], usize) = $crate::uniques::merge_nty_lists(BOTH);
+            const SMALL_RPT: [&'static $crate::postcard_schema::schema::NamedType; BIG_RPT.1] = $crate::uniques::cruncher(BIG_RPT.0.as_slice());
             SMALL_RPT.as_slice()
         }
     };

--- a/source/postcard-rpc/src/server/dispatch_macro.rs
+++ b/source/postcard-rpc/src/server/dispatch_macro.rs
@@ -406,15 +406,15 @@ macro_rules! define_dispatch {
                 ) -> Self {
                     const MAP: &$crate::DeviceMap = &$crate::DeviceMap {
                         types: const {
-                            const LISTS: &[&[&'static postcard_schema::schema::NamedType]] = &[
+                            const LISTS: &[&[&'static $crate::postcard_schema::schema::NamedType]] = &[
                                 $endpoint_list.types,
                                 $topic_in_list.types,
                                 $topic_out_list.types,
                             ];
                             const TTL_COUNT: usize = $endpoint_list.types.len() + $topic_in_list.types.len() + $topic_out_list.types.len();
 
-                            const BIG_RPT: ([Option<&'static postcard_schema::schema::NamedType>; TTL_COUNT], usize) = $crate::uniques::merge_nty_lists(LISTS);
-                            const SMALL_RPT: [&'static postcard_schema::schema::NamedType; BIG_RPT.1] = $crate::uniques::cruncher(BIG_RPT.0.as_slice());
+                            const BIG_RPT: ([Option<&'static $crate::postcard_schema::schema::NamedType>; TTL_COUNT], usize) = $crate::uniques::merge_nty_lists(LISTS);
+                            const SMALL_RPT: [&'static $crate::postcard_schema::schema::NamedType; BIG_RPT.1] = $crate::uniques::cruncher(BIG_RPT.0.as_slice());
                             SMALL_RPT.as_slice()
                         },
                         endpoints: &$endpoint_list.endpoints,

--- a/source/postcard-rpc/src/server/dispatch_macro.rs
+++ b/source/postcard-rpc/src/server/dispatch_macro.rs
@@ -150,7 +150,7 @@ macro_rules! define_dispatch {
                     // Standard ICD endpoints
                     <$crate::standard_icd::PingEndpoint as $crate::Endpoint>::$req_key_name => {
                         // Can we deserialize the request?
-                        let Ok(req) = postcard::from_bytes::<<$crate::standard_icd::PingEndpoint as $crate::Endpoint>::Request>(body) else {
+                        let Ok(req) = $crate::postcard::from_bytes::<<$crate::standard_icd::PingEndpoint as $crate::Endpoint>::Request>(body) else {
                             let err = $crate::standard_icd::WireError::DeserFailed;
                             return tx.error(hdr.seq_no, err).await;
                         };
@@ -164,7 +164,7 @@ macro_rules! define_dispatch {
                     $(
                         <$endpoint as $crate::Endpoint>::$req_key_name => {
                             // Can we deserialize the request?
-                            let Ok(req) = postcard::from_bytes::<<$endpoint as $crate::Endpoint>::Request>(body) else {
+                            let Ok(req) = $crate::postcard::from_bytes::<<$endpoint as $crate::Endpoint>::Request>(body) else {
                                 let err = $crate::standard_icd::WireError::DeserFailed;
                                 return tx.error(hdr.seq_no, err).await;
                             };
@@ -185,7 +185,7 @@ macro_rules! define_dispatch {
                     $(
                         <$topic_in as $crate::Topic>::$topic_key_name => {
                             // Can we deserialize the request?
-                            let Ok(msg) = postcard::from_bytes::<<$topic_in as $crate::Topic>::Message>(body) else {
+                            let Ok(msg) = $crate::postcard::from_bytes::<<$topic_in as $crate::Topic>::Message>(body) else {
                                 // This is a topic, not much to be done
                                 return Ok(());
                             };


### PR DESCRIPTION
the macros reference `postcard` & `postcard-schema` and expect their callers to add the dependency.
this has two downsides:
* this dependency leaks to the caller
* we have no guarantee as to which version the caller adds (and with which features), thus we don't know whether it'll actually compile

by re-exporting it and referencing our re-export we can resolve this issue. the re-export is hidden from the docs as consumers are not supposed to use it directly.

resolves #105