### PR TITLE
add necessary `#[derive(Debug)]` for `HostClient`

### DIFF
--- a/example/workbook-host/src/client.rs
+++ b/example/workbook-host/src/client.rs
@@ -10,6 +10,7 @@ use workbook_icd::{
     StopAccelerationEndpoint,
 };
 
+#[derive(Debug)]
 pub struct WorkbookClient {
     pub client: HostClient<WireError>,
 }

--- a/example/workbook-host/src/lib.rs
+++ b/example/workbook-host/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(missing_debug_implementations)]
+
 pub mod client;
 pub use workbook_icd as icd;
 

--- a/source/postcard-rpc/src/host_client/mod.rs
+++ b/source/postcard-rpc/src/host_client/mod.rs
@@ -176,6 +176,7 @@ pub trait WireSpawn: 'static {
 ///
 /// 1. With raw USB Bulk transfers: [`HostClient::new_raw_nusb()`] (**recommended**)
 /// 2. With cobs CDC-ACM transfers: [`HostClient::new_serial_cobs()`]
+#[derive(Debug)]
 pub struct HostClient<WireErr> {
     ctx: Arc<HostContext>,
     out: mpsc::Sender<RpcFrame>,
@@ -922,6 +923,7 @@ impl RpcFrame {
 }
 
 /// Shared context between [HostClient] and the I/O worker task
+#[derive(Debug)]
 pub struct HostContext {
     kkind: RwLock<VarKeyKind>,
     map: WaitMap<VarHeader, (VarHeader, Vec<u8>)>,

--- a/source/postcard-rpc/src/host_client/util.rs
+++ b/source/postcard-rpc/src/host_client/util.rs
@@ -29,7 +29,7 @@ pub(crate) struct Subscriptions {
 /// A basic cancellation-token
 ///
 /// Used to terminate (and signal termination of) worker tasks
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Stopper {
     inner: Arc<WaitQueue>,
 }


### PR DESCRIPTION
this way it is possible to add the same to any wrapper struct (e.g. `WorkbookClient` in the example). this allows enabling the `missing_debug_implementations` lint.