### PR TITLE
Fix incorrect trailing comma in book

### DIFF
--- a/book/src/comms-postcard-rpc.md
+++ b/book/src/comms-postcard-rpc.md
@@ -69,7 +69,7 @@ endpoint!(
     SleepEndpoint,  // This is the NAME of the Endpoint
     Sleep,          // This is the Request type
     SleepDone,      // This is the Response type
-    "sleep",        // This is the "path" of the endpoint
+    "sleep"         // This is the "path" of the endpoint
 );
 
 


### PR DESCRIPTION
With this comma, the code fails to compile with:

```
    Checking protocol v0.1.0 (X:\postcard_rpc_test\protocol)
error: macros that expand to items must be delimited with braces or followed by a semicolon
  --> src\lib.rs:21:1
   |
21 | / endpoint!(
22 | |     SleepEndpoint, // This is the NAME of the Endpoint
23 | |     Sleep,         // This is the Request type
24 | |     SleepDone,     // This is the Response type
25 | |     "sleep",       // This is the "path" of the endpoint
26 | | );
   | |_^
   |
   = note: this error originates in the macro `endpoint` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `protocol` (lib) due to 1 previous error
```