### PR TITLE
run CI also on Windows and MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,12 @@ concurrency:
 permissions: {}
 
 jobs:
-  ubuntu:
-    runs-on: ubuntu-latest
+  ci:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - run: ./ci.sh
+        shell: bash


### PR DESCRIPTION
this ensures that all main platforms supported by GitHub Actions are covered in the CI.

bash is also installed on non-Linux runner images, thus the CI script can also be run there.