### PR TITLE
host client: change "receiver closed" log to info

### DIFF
--- a/source/postcard-rpc/src/host_client/util.rs
+++ b/source/postcard-rpc/src/host_client/util.rs
@@ -182,7 +182,7 @@ where
 {
     loop {
         let Some(msg) = rec.recv().await else {
-            tracing::warn!("Receiver Closed, this could be bad");
+            tracing::info!("Receiver Closed");
             return;
         };
         if let Err(e) = wire.send(msg.to_bytes()).await {


### PR DESCRIPTION
this happens every time the `HostClient` is dropped and there's nothing wrong with this per-se. it _can_ indicate a problem, but only if it was not dropped intentionally.

there's theoretically the possibility to call `HostClient::close`, but that generally isn't necessary as the drop handlers take care of everything.