### PR TITLE
 add formatting check to CI & reformat all code

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -7,6 +7,17 @@ rustup target add \
     riscv32imac-unknown-none-elf \
     wasm32-unknown-unknown
 
+# formatting
+cargo fmt --all --manifest-path source/postcard-rpc/Cargo.toml -- --check
+cargo fmt --all --manifest-path example/workbook-host/Cargo.toml -- --check
+cargo fmt --all --manifest-path example/serial-host/Cargo.toml -- --check
+cargo fmt --all --manifest-path example/firmware/Cargo.toml -- --check
+cargo fmt --all --manifest-path example/firmware-eusb-v0_4/Cargo.toml -- --check
+cargo fmt --all --manifest-path example/firmware-eusb-v0_3/Cargo.toml -- --check
+cargo fmt --all --manifest-path example/nrf52840-serial/Cargo.toml -- --check
+cargo fmt --all --manifest-path example/esp32c6-serial/Cargo.toml -- --check
+cargo fmt --all --manifest-path source/postcard-rpc-test/Cargo.toml -- --check
+
 # Host + STD checks
 cargo check \
     --manifest-path source/postcard-rpc/Cargo.toml \

--- a/example/esp32c6-serial/build.rs
+++ b/example/esp32c6-serial/build.rs
@@ -15,7 +15,9 @@ fn linker_be_nice() {
             "undefined-symbol" => match what.as_str() {
                 "_defmt_timestamp" => {
                     eprintln!();
-                    eprintln!("💡 `defmt` not found - make sure `defmt.x` is added as a linker script and you have included `use defmt_rtt as _;`");
+                    eprintln!(
+                        "💡 `defmt` not found - make sure `defmt.x` is added as a linker script and you have included `use defmt_rtt as _;`"
+                    );
                     eprintln!();
                 }
                 "_stack_start" => {
@@ -27,12 +29,16 @@ fn linker_be_nice() {
                 | "esp_wifi_preempt_yield_task"
                 | "esp_wifi_preempt_task_create" => {
                     eprintln!();
-                    eprintln!("💡 `esp-wifi` has no scheduler enabled. Make sure you have the `builtin-scheduler` feature enabled, or that you provide an external scheduler.");
+                    eprintln!(
+                        "💡 `esp-wifi` has no scheduler enabled. Make sure you have the `builtin-scheduler` feature enabled, or that you provide an external scheduler."
+                    );
                     eprintln!();
                 }
                 "embedded_test_linker_file_not_added_to_rustflags" => {
                     eprintln!();
-                    eprintln!("💡 `embedded-test` not found - make sure `embedded-test.x` is added as a linker script for tests");
+                    eprintln!(
+                        "💡 `embedded-test` not found - make sure `embedded-test.x` is added as a linker script for tests"
+                    );
                     eprintln!();
                 }
                 _ => (),

--- a/example/firmware-eusb-v0_4/src/bin/minimal.rs
+++ b/example/firmware-eusb-v0_4/src/bin/minimal.rs
@@ -2,7 +2,6 @@
 
 #![no_std]
 #![no_main]
-
 #![deny(missing_docs)]
 
 use defmt::info;

--- a/example/firmware/src/bin/minimal.rs
+++ b/example/firmware/src/bin/minimal.rs
@@ -2,7 +2,6 @@
 
 #![no_std]
 #![no_main]
-
 #![deny(missing_docs)]
 
 use defmt::info;

--- a/example/serial-host/src/main.rs
+++ b/example/serial-host/src/main.rs
@@ -1,6 +1,10 @@
 use std::time::Duration;
 
-use postcard_rpc::{header::VarSeqKind, host_client::HostClient, standard_icd::{PingEndpoint, WireError}};
+use postcard_rpc::{
+    header::VarSeqKind,
+    host_client::HostClient,
+    standard_icd::{PingEndpoint, WireError},
+};
 use tokio::time::sleep;
 
 #[tokio::main]
@@ -12,13 +16,8 @@ async fn main() {
 
     println!("Connecting to {dev}...");
 
-    let client = HostClient::<WireError>::new_serial_cobs(
-        dev,
-        "error",
-        64,
-        115_200,
-        VarSeqKind::Seq2,
-    );
+    let client =
+        HostClient::<WireError>::new_serial_cobs(dev, "error", 64, 115_200, VarSeqKind::Seq2);
 
     println!("Connected :)");
 

--- a/example/workbook-host/src/bin/comms-02.rs
+++ b/example/workbook-host/src/bin/comms-02.rs
@@ -68,7 +68,11 @@ async fn main() {
                     }
                 };
 
-                let mut sub = client.client.subscribe_multi::<icd::AccelTopic>(8).await.unwrap();
+                let mut sub = client
+                    .client
+                    .subscribe_multi::<icd::AccelTopic>(8)
+                    .await
+                    .unwrap();
                 client.start_accelerometer(ms, range).await.unwrap();
                 println!("Started!");
                 let dur = Duration::from_millis(dur.into());

--- a/example/workbook-host/src/bin/comms-serial.rs
+++ b/example/workbook-host/src/bin/comms-serial.rs
@@ -80,7 +80,11 @@ async fn main() {
                     }
                 };
 
-                let mut sub = client.client.subscribe_multi::<icd::AccelTopic>(8).await.unwrap();
+                let mut sub = client
+                    .client
+                    .subscribe_multi::<icd::AccelTopic>(8)
+                    .await
+                    .unwrap();
                 client.start_accelerometer(ms, range).await.unwrap();
                 println!("Started!");
                 let dur = Duration::from_millis(dur.into());

--- a/example/workbook-host/src/bin/logging.rs
+++ b/example/workbook-host/src/bin/logging.rs
@@ -10,7 +10,11 @@ async fn main() {
     println!("Got: {ping}.");
     println!();
 
-    let mut logsub = client.client.subscribe_multi::<LoggingTopic>(64).await.unwrap();
+    let mut logsub = client
+        .client
+        .subscribe_multi::<LoggingTopic>(64)
+        .await
+        .unwrap();
 
     while let Ok(msg) = logsub.recv().await {
         println!("LOG: {msg}");

--- a/example/workbook-host/src/client.rs
+++ b/example/workbook-host/src/client.rs
@@ -55,13 +55,7 @@ impl WorkbookClient {
     }
 
     pub fn new_serial(port: &str) -> Self {
-        let client = HostClient::new_serial_cobs(
-            port,
-            ERROR_PATH,
-            8,
-            9600,
-            VarSeqKind::Seq2,
-        );
+        let client = HostClient::new_serial_cobs(port, ERROR_PATH, 8, 9600, VarSeqKind::Seq2);
         Self { client }
     }
 

--- a/source/postcard-rpc-test/tests/subscrobble.rs
+++ b/source/postcard-rpc-test/tests/subscrobble.rs
@@ -6,7 +6,10 @@ use std::sync::Arc;
 
 use postcard_schema::Schema;
 use serde::{Deserialize, Serialize};
-use tokio::{sync::mpsc, time::{sleep, timeout}};
+use tokio::{
+    sync::mpsc,
+    time::{sleep, timeout},
+};
 
 use postcard_rpc::{
     define_dispatch, endpoints,
@@ -262,9 +265,18 @@ async fn exclusive_subs_work() {
     let cli = client::new_from_channels(client_tx, client_rx, VarSeqKind::Seq1);
     #[allow(deprecated)]
     let mut sub = cli.subscribe::<ZetaTopic10>(16).await.unwrap();
-    server_sender.publish::<ZetaTopic10>(VarSeq::Seq4(1), &ZMsg(10)).await.unwrap();
-    server_sender.publish::<ZetaTopic10>(VarSeq::Seq4(2), &ZMsg(20)).await.unwrap();
-    server_sender.publish::<ZetaTopic10>(VarSeq::Seq4(3), &ZMsg(30)).await.unwrap();
+    server_sender
+        .publish::<ZetaTopic10>(VarSeq::Seq4(1), &ZMsg(10))
+        .await
+        .unwrap();
+    server_sender
+        .publish::<ZetaTopic10>(VarSeq::Seq4(2), &ZMsg(20))
+        .await
+        .unwrap();
+    server_sender
+        .publish::<ZetaTopic10>(VarSeq::Seq4(3), &ZMsg(30))
+        .await
+        .unwrap();
     let get_fut = async move {
         assert_eq!(sub.recv().await.unwrap(), ZMsg(10));
         assert_eq!(sub.recv().await.unwrap(), ZMsg(20));
@@ -275,9 +287,18 @@ async fn exclusive_subs_work() {
     // Old subs are killed
     #[allow(deprecated)]
     let mut sub2 = cli.subscribe::<ZetaTopic10>(16).await.unwrap();
-    server_sender.publish::<ZetaTopic10>(VarSeq::Seq4(1), &ZMsg(11)).await.unwrap();
-    server_sender.publish::<ZetaTopic10>(VarSeq::Seq4(2), &ZMsg(21)).await.unwrap();
-    server_sender.publish::<ZetaTopic10>(VarSeq::Seq4(3), &ZMsg(31)).await.unwrap();
+    server_sender
+        .publish::<ZetaTopic10>(VarSeq::Seq4(1), &ZMsg(11))
+        .await
+        .unwrap();
+    server_sender
+        .publish::<ZetaTopic10>(VarSeq::Seq4(2), &ZMsg(21))
+        .await
+        .unwrap();
+    server_sender
+        .publish::<ZetaTopic10>(VarSeq::Seq4(3), &ZMsg(31))
+        .await
+        .unwrap();
     // Ensure the sender has a chance to send the messages
     sleep(Duration::from_millis(10)).await;
     #[allow(deprecated)]
@@ -290,9 +311,18 @@ async fn exclusive_subs_work() {
         assert!(sub2.recv().await.is_none());
     };
     let _: () = timeout(Duration::from_millis(100), get_fut).await.unwrap();
-    server_sender.publish::<ZetaTopic10>(VarSeq::Seq4(1), &ZMsg(12)).await.unwrap();
-    server_sender.publish::<ZetaTopic10>(VarSeq::Seq4(2), &ZMsg(22)).await.unwrap();
-    server_sender.publish::<ZetaTopic10>(VarSeq::Seq4(3), &ZMsg(32)).await.unwrap();
+    server_sender
+        .publish::<ZetaTopic10>(VarSeq::Seq4(1), &ZMsg(12))
+        .await
+        .unwrap();
+    server_sender
+        .publish::<ZetaTopic10>(VarSeq::Seq4(2), &ZMsg(22))
+        .await
+        .unwrap();
+    server_sender
+        .publish::<ZetaTopic10>(VarSeq::Seq4(3), &ZMsg(32))
+        .await
+        .unwrap();
     let get_fut = async move {
         assert_eq!(sub3.recv().await.unwrap(), ZMsg(12));
         assert_eq!(sub3.recv().await.unwrap(), ZMsg(22));
@@ -300,15 +330,23 @@ async fn exclusive_subs_work() {
     };
     let _: () = timeout(Duration::from_millis(100), get_fut).await.unwrap();
 
-
     // Broadcast does not interfere
     #[allow(deprecated)]
     let mut sub4 = cli.subscribe::<ZetaTopic10>(16).await.unwrap();
     let mut sub5 = cli.subscribe_multi::<ZetaTopic10>(16).await.unwrap();
     sleep(Duration::from_millis(10)).await;
-    server_sender.publish::<ZetaTopic10>(VarSeq::Seq4(1), &ZMsg(15)).await.unwrap();
-    server_sender.publish::<ZetaTopic10>(VarSeq::Seq4(2), &ZMsg(25)).await.unwrap();
-    server_sender.publish::<ZetaTopic10>(VarSeq::Seq4(3), &ZMsg(35)).await.unwrap();
+    server_sender
+        .publish::<ZetaTopic10>(VarSeq::Seq4(1), &ZMsg(15))
+        .await
+        .unwrap();
+    server_sender
+        .publish::<ZetaTopic10>(VarSeq::Seq4(2), &ZMsg(25))
+        .await
+        .unwrap();
+    server_sender
+        .publish::<ZetaTopic10>(VarSeq::Seq4(3), &ZMsg(35))
+        .await
+        .unwrap();
     // Ensure the sender has a chance to send the messages
     sleep(Duration::from_millis(10)).await;
     #[allow(deprecated)]
@@ -322,8 +360,12 @@ async fn exclusive_subs_work() {
         assert_eq!(sub5.recv().await.unwrap(), ZMsg(25));
         assert_eq!(sub5.recv().await.unwrap(), ZMsg(35));
     };
-    let _: () = timeout(Duration::from_millis(100), get_fut_excl).await.unwrap();
-    let _: () = timeout(Duration::from_millis(100), get_fut_bcst).await.unwrap();
+    let _: () = timeout(Duration::from_millis(100), get_fut_excl)
+        .await
+        .unwrap();
+    let _: () = timeout(Duration::from_millis(100), get_fut_bcst)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -363,9 +405,18 @@ async fn broadcast_subs_work() {
     // Multi-Subbing works
     let mut sub1 = cli.subscribe_multi::<ZetaTopic10>(16).await.unwrap();
     let mut sub2 = cli.subscribe_multi::<ZetaTopic10>(16).await.unwrap();
-    server_sender.publish::<ZetaTopic10>(VarSeq::Seq4(1), &ZMsg(10)).await.unwrap();
-    server_sender.publish::<ZetaTopic10>(VarSeq::Seq4(2), &ZMsg(20)).await.unwrap();
-    server_sender.publish::<ZetaTopic10>(VarSeq::Seq4(3), &ZMsg(30)).await.unwrap();
+    server_sender
+        .publish::<ZetaTopic10>(VarSeq::Seq4(1), &ZMsg(10))
+        .await
+        .unwrap();
+    server_sender
+        .publish::<ZetaTopic10>(VarSeq::Seq4(2), &ZMsg(20))
+        .await
+        .unwrap();
+    server_sender
+        .publish::<ZetaTopic10>(VarSeq::Seq4(3), &ZMsg(30))
+        .await
+        .unwrap();
     let get_fut1 = async move {
         assert_eq!(sub1.recv().await.unwrap(), ZMsg(10));
         assert_eq!(sub1.recv().await.unwrap(), ZMsg(20));
@@ -384,9 +435,18 @@ async fn broadcast_subs_work() {
     let mut sub4 = cli.subscribe_multi::<ZetaTopic10>(16).await.unwrap();
     #[allow(deprecated)]
     let mut sub5 = cli.subscribe::<ZetaTopic10>(16).await.unwrap();
-    server_sender.publish::<ZetaTopic10>(VarSeq::Seq4(1), &ZMsg(10)).await.unwrap();
-    server_sender.publish::<ZetaTopic10>(VarSeq::Seq4(2), &ZMsg(20)).await.unwrap();
-    server_sender.publish::<ZetaTopic10>(VarSeq::Seq4(3), &ZMsg(30)).await.unwrap();
+    server_sender
+        .publish::<ZetaTopic10>(VarSeq::Seq4(1), &ZMsg(10))
+        .await
+        .unwrap();
+    server_sender
+        .publish::<ZetaTopic10>(VarSeq::Seq4(2), &ZMsg(20))
+        .await
+        .unwrap();
+    server_sender
+        .publish::<ZetaTopic10>(VarSeq::Seq4(3), &ZMsg(30))
+        .await
+        .unwrap();
     let get_fut1 = async move {
         assert_eq!(sub3.recv().await.unwrap(), ZMsg(10));
         assert_eq!(sub3.recv().await.unwrap(), ZMsg(20));
@@ -405,5 +465,4 @@ async fn broadcast_subs_work() {
     let _: () = timeout(Duration::from_millis(100), get_fut1).await.unwrap();
     let _: () = timeout(Duration::from_millis(100), get_fut2).await.unwrap();
     let _: () = timeout(Duration::from_millis(100), get_fut3).await.unwrap();
-
 }

--- a/source/postcard-rpc/src/server/impls/embassy_usb_v0_3.rs
+++ b/source/postcard-rpc/src/server/impls/embassy_usb_v0_3.rs
@@ -750,7 +750,10 @@ pub mod fake {
     }
 
     impl EndpointIn for FakeEpIn {
-        async fn write(&mut self, _buf: &[u8]) -> Result<(), embassy_usb_driver_0_1::EndpointError> {
+        async fn write(
+            &mut self,
+            _buf: &[u8],
+        ) -> Result<(), embassy_usb_driver_0_1::EndpointError> {
             todo!()
         }
     }
@@ -824,7 +827,10 @@ pub mod fake {
             todo!()
         }
 
-        fn endpoint_is_stalled(&mut self, _ep_addr: embassy_usb_driver_0_1::EndpointAddress) -> bool {
+        fn endpoint_is_stalled(
+            &mut self,
+            _ep_addr: embassy_usb_driver_0_1::EndpointAddress,
+        ) -> bool {
             todo!()
         }
 

--- a/source/postcard-rpc/src/server/impls/embassy_usb_v0_4.rs
+++ b/source/postcard-rpc/src/server/impls/embassy_usb_v0_4.rs
@@ -455,7 +455,13 @@ impl<M: RawMutex + 'static, D: Driver<'static> + 'static> WireTx for EUsbWireTx<
         // Calculate the TOTAL amount
         let act_used = ttl_len - remain;
 
-        send_all::<D>(ep_in, &tx_buf[..act_used], pending_frame, *timeout_ms_per_frame).await
+        send_all::<D>(
+            ep_in,
+            &tx_buf[..act_used],
+            pending_frame,
+            *timeout_ms_per_frame,
+        )
+        .await
     }
 }
 
@@ -798,7 +804,10 @@ pub mod fake {
     }
 
     impl EndpointIn for FakeEpIn {
-        async fn write(&mut self, _buf: &[u8]) -> Result<(), embassy_usb_driver_0_1::EndpointError> {
+        async fn write(
+            &mut self,
+            _buf: &[u8],
+        ) -> Result<(), embassy_usb_driver_0_1::EndpointError> {
             todo!()
         }
     }
@@ -872,7 +881,10 @@ pub mod fake {
             todo!()
         }
 
-        fn endpoint_is_stalled(&mut self, _ep_addr: embassy_usb_driver_0_1::EndpointAddress) -> bool {
+        fn endpoint_is_stalled(
+            &mut self,
+            _ep_addr: embassy_usb_driver_0_1::EndpointAddress,
+        ) -> bool {
             todo!()
         }
 


### PR DESCRIPTION
i noticed in #130 that `cargo fmt` formatted more than just my new code which meant that there was no check yet => i've added it here and re-formatted all code.

adding it to `ci.sh` is not what i'd usually do (as it now runs on each platform which doesn't make that much sense - it's the same on all of them) but it's in line with how CI is set up in this repo.