### PR TITLE
add missing `impl Error for HostErr`

### DIFF
--- a/example/esp32c6-serial/Cargo.lock
+++ b/example/esp32c6-serial/Cargo.lock
@@ -1030,6 +1030,7 @@ dependencies = [
  "postcard-schema",
  "serde",
  "static_cell",
+ "thiserror",
 ]
 
 [[package]]

--- a/example/firmware-eusb-v0_3/Cargo.lock
+++ b/example/firmware-eusb-v0_3/Cargo.lock
@@ -1158,6 +1158,7 @@ dependencies = [
  "postcard-schema",
  "serde",
  "static_cell",
+ "thiserror 2.0.10",
 ]
 
 [[package]]

--- a/example/firmware-eusb-v0_4/Cargo.lock
+++ b/example/firmware-eusb-v0_4/Cargo.lock
@@ -1163,6 +1163,7 @@ dependencies = [
  "postcard-schema",
  "serde",
  "static_cell",
+ "thiserror 2.0.10",
 ]
 
 [[package]]

--- a/example/firmware/Cargo.lock
+++ b/example/firmware/Cargo.lock
@@ -1360,6 +1360,7 @@ dependencies = [
  "postcard-schema",
  "serde",
  "static_cell",
+ "thiserror 2.0.10",
 ]
 
 [[package]]

--- a/example/nrf52840-serial/Cargo.lock
+++ b/example/nrf52840-serial/Cargo.lock
@@ -675,6 +675,7 @@ dependencies = [
  "postcard-schema",
  "serde",
  "static_cell",
+ "thiserror",
 ]
 
 [[package]]

--- a/example/serial-host/Cargo.lock
+++ b/example/serial-host/Cargo.lock
@@ -598,7 +598,7 @@ dependencies = [
  "postcard-schema",
  "serde",
  "ssmarshal",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-serial",
  "tracing",

--- a/example/workbook-host/Cargo.lock
+++ b/example/workbook-host/Cargo.lock
@@ -113,7 +113,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -122,7 +122,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea6d1b751c55bd9c0dda7d4ff752074e98f4765ae969664648bd193bb326d15"
 dependencies = [
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -638,7 +638,7 @@ dependencies = [
  "postcard-schema",
  "serde",
  "ssmarshal",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "tokio-serial",
  "tracing",
@@ -882,31 +882,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.12",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1050,7 +1030,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c01d12e3a56a4432a8b436f293c25f4808bdf9e9f9f98f9260bba1f1bc5a1f26"
 dependencies = [
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]

--- a/source/postcard-rpc-test/Cargo.lock
+++ b/source/postcard-rpc-test/Cargo.lock
@@ -622,18 +622,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -64,8 +64,8 @@ version = "0.3.69"
 optional = true
 
 [dependencies.thiserror]
-version = "1.0"
-optional = true
+version = "2"
+default-features = false
 
 [dependencies.web-sys]
 
@@ -195,7 +195,7 @@ use-std = [
     "dep:tokio",
     "postcard/use-std",
     "postcard-schema/use-std",
-    "dep:thiserror",
+    "thiserror/std",
     "dep:tracing",
     "dep:trait-variant",
     "dep:ssmarshal",

--- a/source/postcard-rpc/src/host_client/mod.rs
+++ b/source/postcard-rpc/src/host_client/mod.rs
@@ -13,7 +13,6 @@ use std::{
         Arc, RwLock,
     },
 };
-
 use thiserror::Error;
 
 use maitake_sync::{
@@ -52,26 +51,24 @@ pub(crate) mod util;
 pub mod test_channels;
 
 /// Host Error Kind
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Error)]
 pub enum HostErr<WireErr> {
     /// An error of the user-specified wire error type
+    #[error("a wire error occurred")]
     Wire(WireErr),
     /// We got a response that didn't match the expected value or the
     /// user specified wire error type
     ///
     /// This is also (misused) to report when duplicate sequence numbers
     /// in-flight at the same time are detected.
+    #[error("the response received didn't match the expected value or the wire error type")]
     BadResponse,
     /// Deserialization of the message failed
-    Postcard(postcard::Error),
+    #[error("message deserialization failed")]
+    Postcard(#[from] postcard::Error),
     /// The interface has been closed, and no further messages are possible
+    #[error("the interface has been closed, and no further messages are possible")]
     Closed,
-}
-
-impl<T> From<postcard::Error> for HostErr<T> {
-    fn from(value: postcard::Error) -> Self {
-        Self::Postcard(value)
-    }
 }
 
 impl<T> From<WaitError> for HostErr<T> {
@@ -230,17 +227,23 @@ where
 }
 
 /// Errors related to retrieving the schema
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum SchemaError<WireErr> {
     /// Some kind of communication error occurred
-    Comms(HostErr<WireErr>),
+    #[error("A communication error occurred")]
+    Comms(#[from] HostErr<WireErr>),
     /// An error occurred internally. Please open an issue.
+    #[error("An error occurred internally. Please open an issue.")]
     TaskError,
     /// Invalid report data was received, including endpoints or
     /// tasks that referred to unknown types. Please open an issue
+    #[error("Invalid report data was received. Please open an issue.")]
     InvalidReportData,
     /// Data was lost while transmitting. If a retry does not solve
     /// this, please open an issue.
+    #[error(
+        "Data was lost while transmitting. If a retry does not solve this, please open an issue."
+    )]
     LostData,
 }
 


### PR DESCRIPTION
use `thiserror` to do this as it's already used in the crate. this updates it from v1 to v2 and also uses it in `no_std` environments as that's now supported by `thiserror`.

split out from #130 