### PR TITLE
Increase data collection timeout to increase reliability

### DIFF
--- a/source/postcard-rpc/src/host_client/mod.rs
+++ b/source/postcard-rpc/src/host_client/mod.rs
@@ -268,7 +268,7 @@ where
             async move {
                 let mut got = vec![];
                 while let Ok(Ok(val)) =
-                    tokio::time::timeout(Duration::from_millis(100), sub.recv()).await
+                    tokio::time::timeout(Duration::from_millis(500), sub.recv()).await
                 {
                     got.push(val);
                 }


### PR DESCRIPTION
I've had lots of issues where I get an error `LostData` when attempting to use `get_schema_report` even with multiple attempts. I noticed that if I increase the timeout it seems to work much better. 

My server runs at 1 ms intervals on the target, so I'm not sure why 100 ms isn't enough. I'm using a modified version of the your RTT example. Perhaps I should dig deeper, but I don't yet understand everything in enough detail to know where else there might be a problem. 

If you agree that 100 ms is lower than it has to be, then maybe this is an acceptable change. Another idea I had was to make the timeout an input to this method, but that would be a small breaking change.