### PR TITLE
Change URL for James' RustNL 2024 talk.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ See [overview.md](./docs/overview.md) for documentation.
 
 See the [`postcard-rpc` book](https://onevariable.com/postcard-rpc-book/) for a walk-through example.
 
-You can also watch James' [RustNL talk](https://www.youtube.com/live/XLefuzE-ABU?t=24300) for a video explainer of what this crate does.
+You can also watch James' [RustNL talk](https://www.youtube.com/watch?v=HtBFvTH5ZKE) for a video explainer of what this crate does.
 
 ## License
 


### PR DESCRIPTION
Change link to James' RustNL 2024 talk to a dedicated video, which has a clearer audio track.

Sounds like they've either used a recording of the speaker mic on this talk-specific video (instead of the hall mic) or post-processed the audio, but either way there's less reverb on the audio track.