### PR TITLE
Add `nusb v0.2` support

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -25,7 +25,7 @@ cargo test \
     --manifest-path source/postcard-rpc/Cargo.toml \
     --no-default-features
 
-# Host + all non-wasm host-client impls
+# Host + all non-wasm host-client impls with raw-nusb-0_1
 cargo check \
     --manifest-path source/postcard-rpc/Cargo.toml \
     --no-default-features \
@@ -34,6 +34,26 @@ cargo test \
     --manifest-path source/postcard-rpc/Cargo.toml \
     --no-default-features \
     --features=use-std,cobs-serial,raw-nusb
+
+# Host + all non-wasm host-client impls with raw-nusb-0_2
+cargo check \
+    --manifest-path source/postcard-rpc/Cargo.toml \
+    --no-default-features \
+    --features=use-std,cobs-serial,raw-nusb-0_2
+cargo test \
+    --manifest-path source/postcard-rpc/Cargo.toml \
+    --no-default-features \
+    --features=use-std,cobs-serial,raw-nusb-0_2
+
+# Host + all non-wasm host-client impls with raw-nusb-0_1 and raw-nusb-0_2
+cargo check \
+    --manifest-path source/postcard-rpc/Cargo.toml \
+    --no-default-features \
+    --features=use-std,cobs-serial,raw-nusb-0_1,raw-nusb-0_2
+cargo test \
+    --manifest-path source/postcard-rpc/Cargo.toml \
+    --no-default-features \
+    --features=use-std,cobs-serial,raw-nusb-0_1,raw-nusb-0_2
 
 # Host + wasm host-client impls
 RUSTFLAGS="--cfg=web_sys_unstable_apis" \

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -17,7 +17,9 @@ features = [
     "test-utils",
     "use-std",
     "cobs-serial",
-    "raw-nusb",
+    "raw-nusb",  # Alias for raw-nusb-0_1
+    "raw-nusb-0_1",
+    "raw-nusb-0_2",
     "embassy-usb-0_5-server",
     "embedded-io-async-0_6-server",
     "_docs-fix",
@@ -36,8 +38,14 @@ postcard-schema = { version = "0.2.2", features = ["derive"] }
 # std-only features
 #
 
-[dependencies.nusb]
+[dependencies.nusb-0_1]
+package = "nusb"
 version = "0.1.9"
+optional = true
+
+[dependencies.nusb-0_2]
+package = "nusb"
+version = "0.2"
 optional = true
 
 [dependencies.tokio-serial]
@@ -198,7 +206,9 @@ cobs-serial = ["cobs/use_std", "dep:tokio-serial"]
 #
 # Works on: Win, Mac, Linux
 # Does NOT work on: WASM
-raw-nusb = ["dep:nusb", "use-std"]
+raw-nusb = ["raw-nusb-0_1"]
+raw-nusb-0_1 = ["dep:nusb-0_1", "use-std"]
+raw-nusb-0_2 = ["dep:nusb-0_2", "use-std"]
 
 # WebUSB support
 #

--- a/source/postcard-rpc/src/host_client/mod.rs
+++ b/source/postcard-rpc/src/host_client/mod.rs
@@ -36,8 +36,11 @@ use crate::{
 use self::util::Stopper;
 pub use crate::host_client::util::HostClientConfig;
 
-#[cfg(all(feature = "raw-nusb", not(target_family = "wasm")))]
-mod raw_nusb;
+#[cfg(all(feature = "raw-nusb-0_1", not(target_family = "wasm")))]
+mod raw_nusb_0_1;
+
+#[cfg(all(feature = "raw-nusb-0_2", not(target_family = "wasm")))]
+mod raw_nusb_0_2;
 
 #[cfg(all(feature = "cobs-serial", not(target_family = "wasm")))]
 mod serial;

--- a/source/postcard-rpc/src/host_client/raw_nusb_0_1.rs
+++ b/source/postcard-rpc/src/host_client/raw_nusb_0_1.rs
@@ -1,8 +1,9 @@
-//! Implementation of transport using nusb
+//! Implementation of transport using nusb v0.1
 
 use std::future::Future;
 
-use nusb::{
+use nusb_0_1::{
+    self as nusb,
     transfer::{Direction, EndpointType, Queue, RequestBuffer, TransferError},
     DeviceInfo,
 };
@@ -34,7 +35,19 @@ impl<WireErr> HostClient<WireErr>
 where
     WireErr: DeserializeOwned + Schema,
 {
-    /// Try to create a new link using [`nusb`] for connectivity
+    /// Alias for [`try_new_raw_nusb_0_1`] if `raw-nusb-0_2` feature is not enabled.
+    #[cfg(not(feature = "raw-nusb-0_2"))]
+    #[inline]
+    pub fn try_new_raw_nusb<F: FnMut(&DeviceInfo) -> bool>(
+        func: F,
+        err_uri_path: &str,
+        outgoing_depth: usize,
+        seq_no_kind: VarSeqKind,
+    ) -> Result<Self, String> {
+        Self::try_new_raw_nusb_0_1(func, err_uri_path, outgoing_depth, seq_no_kind)
+    }
+
+    /// Try to create a new link using [`nusb`] v0.1 for connectivity
     ///
     /// The provided function will be used to find a matching device. The first
     /// matching device will be connected to. `err_uri_path` is
@@ -43,7 +56,7 @@ where
     /// Returns an error if no device could be found, or if there was an error
     /// connecting to the device.
     ///
-    /// This constructor is available when the `raw-nusb` feature is enabled.
+    /// This constructor is available when the `raw-nusb` or `raw-nusb-0_1` feature is enabled.
     ///
     /// ## Platform specific support
     ///
@@ -67,7 +80,7 @@ where
     ///    SomethingBad
     /// }
     ///
-    /// let client = HostClient::<Error>::try_new_raw_nusb(
+    /// let client = HostClient::<Error>::try_new_raw_nusb_0_1(
     ///     // Find the first device with the serial 12345678
     ///     |d| d.serial_number() == Some("12345678"),
     ///     // the URI/path for `Error` messages
@@ -78,7 +91,7 @@ where
     ///     VarSeqKind::Seq1,
     /// ).unwrap();
     /// ```
-    pub fn try_new_raw_nusb<F: FnMut(&DeviceInfo) -> bool>(
+    pub fn try_new_raw_nusb_0_1<F: FnMut(&DeviceInfo) -> bool>(
         func: F,
         err_uri_path: &str,
         outgoing_depth: usize,
@@ -100,9 +113,31 @@ where
         #[cfg(target_os = "windows")]
         let interface_id = 0;
 
-        Self::try_from_nusb_and_interface(
+        Self::try_from_nusb_and_interface_0_1(
             &x,
             interface_id,
+            err_uri_path,
+            outgoing_depth,
+            seq_no_kind,
+        )
+    }
+
+    /// Alias for [`try_new_raw_nusb_with_interface_0_1`] if `raw-nusb-0_2` feature is not enabled.
+    #[cfg(all(not(feature = "raw-nusb-0_2"), not(target_os = "windows")))]
+    #[inline]
+    pub fn try_new_raw_nusb_with_interface<
+        F1: FnMut(&DeviceInfo) -> bool,
+        F2: FnMut(&nusb::InterfaceInfo) -> bool,
+    >(
+        device_func: F1,
+        interface_func: F2,
+        err_uri_path: &str,
+        outgoing_depth: usize,
+        seq_no_kind: VarSeqKind,
+    ) -> Result<Self, String> {
+        Self::try_new_raw_nusb_with_interface_0_1(
+            device_func,
+            interface_func,
             err_uri_path,
             outgoing_depth,
             seq_no_kind,
@@ -141,7 +176,7 @@ where
     ///    SomethingBad
     /// }
     ///
-    /// let client = HostClient::<Error>::try_new_raw_nusb_with_interface(
+    /// let client = HostClient::<Error>::try_new_raw_nusb_with_interface_0_1(
     ///     // Find the first device with the serial 12345678
     ///     |d| d.serial_number() == Some("12345678"),
     ///     // Find the "Vendor Specific" interface
@@ -155,7 +190,7 @@ where
     /// ).unwrap();
     /// ```
     #[cfg(not(target_os = "windows"))]
-    pub fn try_new_raw_nusb_with_interface<
+    pub fn try_new_raw_nusb_with_interface_0_1<
         F1: FnMut(&DeviceInfo) -> bool,
         F2: FnMut(&nusb::InterfaceInfo) -> bool,
     >(
@@ -174,8 +209,27 @@ where
             .position(interface_func)
             .ok_or_else(|| String::from("Failed to find matching interface!!"))?;
 
-        Self::try_from_nusb_and_interface(
+        Self::try_from_nusb_and_interface_0_1(
             &x,
+            interface_id,
+            err_uri_path,
+            outgoing_depth,
+            seq_no_kind,
+        )
+    }
+
+    /// Alias for [`try_from_nusb_and_interface_0_1`] if `raw-nusb-0_2` feature is not enabled.
+    #[cfg(not(feature = "raw-nusb-0_2"))]
+    #[inline]
+    pub fn try_from_nusb_and_interface(
+        dev: &DeviceInfo,
+        interface_id: usize,
+        err_uri_path: &str,
+        outgoing_depth: usize,
+        seq_no_kind: VarSeqKind,
+    ) -> Result<Self, String> {
+        Self::try_from_nusb_and_interface_0_1(
+            dev,
             interface_id,
             err_uri_path,
             outgoing_depth,
@@ -209,7 +263,7 @@ where
     ///
     /// // Assume the first usb device is the one we're interested
     /// let dev = nusb::list_devices().unwrap().next().unwrap();
-    /// let client = HostClient::<Error>::try_from_nusb_and_interface(
+    /// let client = HostClient::<Error>::try_from_nusb_and_interface_0_1(
     ///     // Device to open
     ///     &dev,
     ///     // Use the first interface (0)
@@ -222,7 +276,7 @@ where
     ///     VarSeqKind::Seq1,
     /// ).unwrap();
     /// ```
-    pub fn try_from_nusb_and_interface(
+    pub fn try_from_nusb_and_interface_0_1(
         dev: &DeviceInfo,
         interface_id: usize,
         err_uri_path: &str,
@@ -288,9 +342,21 @@ where
         ))
     }
 
+    /// Alias for [`new_raw_nusb_0_1`] if `raw-nusb-0_2` feature is not enabled.
+    #[cfg(not(feature = "raw-nusb-0_2"))]
+    #[inline]
+    pub fn new_raw_nusb<F: FnMut(&DeviceInfo) -> bool>(
+        func: F,
+        err_uri_path: &str,
+        outgoing_depth: usize,
+        seq_no_kind: VarSeqKind,
+    ) -> Self {
+        Self::new_raw_nusb_0_1(func, err_uri_path, outgoing_depth, seq_no_kind)
+    }
+
     /// Create a new link using [`nusb`] for connectivity
     ///
-    /// Panics if connection fails. See [`Self::try_new_raw_nusb()`] for more details.
+    /// Panics if connection fails. See [`Self::try_new_raw_nusb_0_1()`] for more details.
     ///
     /// This constructor is available when the `raw-nusb` feature is enabled.
     ///
@@ -309,7 +375,7 @@ where
     ///    SomethingBad
     /// }
     ///
-    /// let client = HostClient::<Error>::new_raw_nusb(
+    /// let client = HostClient::<Error>::new_raw_nusb_0_1(
     ///     // Find the first device with the serial 12345678
     ///     |d| d.serial_number() == Some("12345678"),
     ///     // the URI/path for `Error` messages
@@ -320,13 +386,13 @@ where
     ///     VarSeqKind::Seq1,
     /// );
     /// ```
-    pub fn new_raw_nusb<F: FnMut(&DeviceInfo) -> bool>(
+    pub fn new_raw_nusb_0_1<F: FnMut(&DeviceInfo) -> bool>(
         func: F,
         err_uri_path: &str,
         outgoing_depth: usize,
         seq_no_kind: VarSeqKind,
     ) -> Self {
-        Self::try_new_raw_nusb(func, err_uri_path, outgoing_depth, seq_no_kind)
+        Self::try_new_raw_nusb_0_1(func, err_uri_path, outgoing_depth, seq_no_kind)
             .expect("should have found nusb device")
     }
 }

--- a/source/postcard-rpc/src/host_client/raw_nusb_0_1.rs
+++ b/source/postcard-rpc/src/host_client/raw_nusb_0_1.rs
@@ -249,6 +249,7 @@ where
     /// ## Example
     ///
     /// ```rust,no_run
+    /// # use nusb_0_1 as nusb;
     /// use postcard_rpc::host_client::HostClient;
     /// use postcard_rpc::header::VarSeqKind;
     /// use serde::{Serialize, Deserialize};

--- a/source/postcard-rpc/src/host_client/raw_nusb_0_2.rs
+++ b/source/postcard-rpc/src/host_client/raw_nusb_0_2.rs
@@ -28,7 +28,7 @@ pub(crate) const MAX_STALL_RETRIES: usize = 10;
 
 /// # `nusb` Constructor Methods
 ///
-/// These methods are used to create a new [HostClient] instance for use with `nusb` 0.2 
+/// These methods are used to create a new [HostClient] instance for use with `nusb` 0.2
 /// and USB bulk transfer encoding.
 ///
 /// **Requires feature**: `raw-nusb-0_2`
@@ -252,6 +252,7 @@ where
     /// ## Example
     ///
     /// ```rust,no_run
+    /// # use nusb_0_2::{self as nusb, MaybeFuture};
     /// use postcard_rpc::host_client::HostClient;
     /// use postcard_rpc::header::VarSeqKind;
     /// use serde::{Serialize, Deserialize};

--- a/source/postcard-rpc/src/host_client/raw_nusb_0_2.rs
+++ b/source/postcard-rpc/src/host_client/raw_nusb_0_2.rs
@@ -1,0 +1,589 @@
+//! Implementation of transport using nusb v0.2
+
+use std::future::Future;
+
+use nusb_0_2::{
+    self as nusb,
+    descriptors::TransferType,
+    transfer::{self, Buffer, Direction, TransferError},
+    DeviceInfo, Endpoint, MaybeFuture,
+};
+use postcard_schema::Schema;
+use serde::de::DeserializeOwned;
+
+use crate::{
+    header::VarSeqKind,
+    host_client::{HostClient, WireRx, WireSpawn, WireTx},
+};
+
+// TODO: These should all be configurable, PRs welcome
+
+/// The size in bytes of the largest possible IN transfer
+pub(crate) const MAX_TRANSFER_SIZE: usize = 1024;
+/// How many in-flight requests at once - allows nusb to keep pulling frames
+/// even if we haven't processed them host-side yet.
+pub(crate) const IN_FLIGHT_REQS: usize = 4;
+/// How many consecutive IN errors will we try to recover from before giving up?
+pub(crate) const MAX_STALL_RETRIES: usize = 10;
+
+/// # `nusb` Constructor Methods
+///
+/// These methods are used to create a new [HostClient] instance for use with `nusb` 0.2 
+/// and USB bulk transfer encoding.
+///
+/// **Requires feature**: `raw-nusb-0_2`
+impl<WireErr> HostClient<WireErr>
+where
+    WireErr: DeserializeOwned + Schema,
+{
+    /// Alias for [`try_new_raw_nusb_0_2`] if `raw-nusb-0_1` feature is not enabled.
+    #[cfg(not(feature = "raw-nusb-0_1"))]
+    #[inline]
+    pub fn try_new_raw_nusb<F: FnMut(&DeviceInfo) -> bool>(
+        func: F,
+        err_uri_path: &str,
+        outgoing_depth: usize,
+        seq_no_kind: VarSeqKind,
+    ) -> Result<Self, String> {
+        Self::try_new_raw_nusb_0_2(func, err_uri_path, outgoing_depth, seq_no_kind)
+    }
+
+    /// Try to create a new link using [`nusb`] for connectivity
+    ///
+    /// The provided function will be used to find a matching device. The first
+    /// matching device will be connected to. `err_uri_path` is
+    /// the path associated with the `WireErr` message type.
+    ///
+    /// Returns an error if no device could be found, or if there was an error
+    /// connecting to the device.
+    ///
+    /// This constructor is available when the `raw-nusb` feature is enabled.
+    ///
+    /// ## Platform specific support
+    ///
+    /// When using Windows, the WinUSB driver does not allow enumerating interfaces.
+    /// When on windows, this method will ALWAYS try to connect to interface zero.
+    /// This limitation may be removed in the future, and if so, will be changed to
+    /// look for the first interface with the class of 0xFF.
+    ///
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// use postcard_rpc::host_client::HostClient;
+    /// use postcard_rpc::header::VarSeqKind;
+    /// use serde::{Serialize, Deserialize};
+    /// use postcard_schema::Schema;
+    ///
+    /// /// A "wire error" type your server can use to respond to any
+    /// /// kind of request, for example if deserializing a request fails
+    /// #[derive(Debug, PartialEq, Schema, Serialize, Deserialize)]
+    /// pub enum Error {
+    ///    SomethingBad
+    /// }
+    ///
+    /// let client = HostClient::<Error>::try_new_raw_nusb_0_2(
+    ///     // Find the first device with the serial 12345678
+    ///     |d| d.serial_number() == Some("12345678"),
+    ///     // the URI/path for `Error` messages
+    ///     "error",
+    ///     // Outgoing queue depth in messages
+    ///     8,
+    ///     // Use one-byte sequence numbers
+    ///     VarSeqKind::Seq1,
+    /// ).unwrap();
+    /// ```
+    pub fn try_new_raw_nusb_0_2<F: FnMut(&DeviceInfo) -> bool>(
+        func: F,
+        err_uri_path: &str,
+        outgoing_depth: usize,
+        seq_no_kind: VarSeqKind,
+    ) -> Result<Self, String> {
+        let x = nusb::list_devices()
+            .wait()
+            .map_err(|e| format!("Error listing devices: {e:?}"))?
+            .find(func)
+            .ok_or_else(|| String::from("Failed to find matching nusb device!"))?;
+
+        // NOTE: We can't enumerate interfaces on Windows. For now, just use
+        // a hardcoded interface of zero instead of trying to find the right one
+        #[cfg(not(target_os = "windows"))]
+        let interface_id = x
+            .interfaces()
+            .position(|i| i.class() == 0xFF)
+            .ok_or_else(|| String::from("Failed to find matching interface!!"))?;
+
+        #[cfg(target_os = "windows")]
+        let interface_id = 0;
+
+        Self::try_from_nusb_and_interface_0_2(
+            &x,
+            interface_id,
+            err_uri_path,
+            outgoing_depth,
+            seq_no_kind,
+        )
+    }
+
+    /// Alias for [`try_new_raw_nusb_with_interface_0_2`] if `raw-nusb-0_1` feature is not enabled.
+    #[cfg(all(not(feature = "raw-nusb-0_1"), not(target_os = "windows")))]
+    #[inline]
+    pub fn try_new_raw_nusb_with_interface<
+        F1: FnMut(&DeviceInfo) -> bool,
+        F2: FnMut(&nusb::InterfaceInfo) -> bool,
+    >(
+        device_func: F1,
+        interface_func: F2,
+        err_uri_path: &str,
+        outgoing_depth: usize,
+        seq_no_kind: VarSeqKind,
+    ) -> Result<Self, String> {
+        Self::try_new_raw_nusb_with_interface_0_2(
+            device_func,
+            interface_func,
+            err_uri_path,
+            outgoing_depth,
+            seq_no_kind,
+        )
+    }
+
+    /// Try to create a new link using [`nusb`] for connectivity
+    ///
+    /// The provided function will be used to find a matching device and interface. The first
+    /// matching device will be connected to. `err_uri_path` is
+    /// the path associated with the `WireErr` message type.
+    ///
+    /// Returns an error if no device or interface could be found, or if there was an error
+    /// connecting to the device or interface.
+    ///
+    /// This constructor is available when the `raw-nusb` feature is enabled.
+    ///
+    /// ## Platform specific support
+    ///
+    /// When using Windows, the WinUSB driver does not allow enumerating interfaces.
+    /// Therefore, this constructor is not available on windows. This limitation may
+    /// be removed in the future.
+    ///
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// use postcard_rpc::host_client::HostClient;
+    /// use postcard_rpc::header::VarSeqKind;
+    /// use serde::{Serialize, Deserialize};
+    /// use postcard_schema::Schema;
+    ///
+    /// /// A "wire error" type your server can use to respond to any
+    /// /// kind of request, for example if deserializing a request fails
+    /// #[derive(Debug, PartialEq, Schema, Serialize, Deserialize)]
+    /// pub enum Error {
+    ///    SomethingBad
+    /// }
+    ///
+    /// let client = HostClient::<Error>::try_new_raw_nusb_with_interface_0_2(
+    ///     // Find the first device with the serial 12345678
+    ///     |d| d.serial_number() == Some("12345678"),
+    ///     // Find the "Vendor Specific" interface
+    ///     |i| i.class() == 0xFF,
+    ///     // the URI/path for `Error` messages
+    ///     "error",
+    ///     // Outgoing queue depth in messages
+    ///     8,
+    ///     // Use one-byte sequence numbers
+    ///     VarSeqKind::Seq1,
+    /// ).unwrap();
+    /// ```
+    #[cfg(not(target_os = "windows"))]
+    pub fn try_new_raw_nusb_with_interface_0_2<
+        F1: FnMut(&DeviceInfo) -> bool,
+        F2: FnMut(&nusb::InterfaceInfo) -> bool,
+    >(
+        device_func: F1,
+        interface_func: F2,
+        err_uri_path: &str,
+        outgoing_depth: usize,
+        seq_no_kind: VarSeqKind,
+    ) -> Result<Self, String> {
+        let x = nusb::list_devices()
+            .wait()
+            .map_err(|e| format!("Error listing devices: {e:?}"))?
+            .find(device_func)
+            .ok_or_else(|| String::from("Failed to find matching nusb device!"))?;
+        let interface_id = x
+            .interfaces()
+            .position(interface_func)
+            .ok_or_else(|| String::from("Failed to find matching interface!!"))?;
+
+        Self::try_from_nusb_and_interface_0_2(
+            &x,
+            interface_id,
+            err_uri_path,
+            outgoing_depth,
+            seq_no_kind,
+        )
+    }
+
+    /// Alias for [`try_from_nusb_and_interface_0_2`] if `raw-nusb-0_1` feature is not enabled.
+    #[cfg(not(feature = "raw-nusb-0_1"))]
+    #[inline]
+    pub fn try_from_nusb_and_interface(
+        dev: &DeviceInfo,
+        interface_id: usize,
+        err_uri_path: &str,
+        outgoing_depth: usize,
+        seq_no_kind: VarSeqKind,
+    ) -> Result<Self, String> {
+        Self::try_from_nusb_and_interface_0_2(
+            dev,
+            interface_id,
+            err_uri_path,
+            outgoing_depth,
+            seq_no_kind,
+        )
+    }
+
+    /// Try to create a new link using [`nusb`] v0.2 for connectivity
+    ///
+    /// This will connect to the given device and interface. `err_uri_path` is
+    /// the path associated with the `WireErr` message type.
+    ///
+    /// Returns an error if there was an error connecting to the device or interface.
+    ///
+    /// This constructor is available when the `raw-nusb` feature is enabled.
+    ///
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// use postcard_rpc::host_client::HostClient;
+    /// use postcard_rpc::header::VarSeqKind;
+    /// use serde::{Serialize, Deserialize};
+    /// use postcard_schema::Schema;
+    ///
+    /// /// A "wire error" type your server can use to respond to any
+    /// /// kind of request, for example if deserializing a request fails
+    /// #[derive(Debug, PartialEq, Schema, Serialize, Deserialize)]
+    /// pub enum Error {
+    ///    SomethingBad
+    /// }
+    ///
+    /// // Assume the first usb device is the one we're interested
+    /// let dev = nusb::list_devices().wait().unwrap().next().unwrap();
+    /// let client = HostClient::<Error>::try_from_nusb_and_interface_0_2(
+    ///     // Device to open
+    ///     &dev,
+    ///     // Use the first interface (0)
+    ///     0,
+    ///     // the URI/path for `Error` messages
+    ///     "error",
+    ///     // Outgoing queue depth in messages
+    ///     8,
+    ///     // Use one-byte sequence numbers
+    ///     VarSeqKind::Seq1,
+    /// ).unwrap();
+    /// ```
+    pub fn try_from_nusb_and_interface_0_2(
+        dev: &DeviceInfo,
+        interface_id: usize,
+        err_uri_path: &str,
+        outgoing_depth: usize,
+        seq_no_kind: VarSeqKind,
+    ) -> Result<Self, String> {
+        let dev = dev
+            .open()
+            .wait()
+            .map_err(|e| format!("Failed opening device: {e:?}"))?;
+        let interface = dev
+            .claim_interface(interface_id as u8)
+            .wait()
+            .map_err(|e| format!("Failed claiming interface: {e:?}"))?;
+
+        let mut mps: Option<usize> = None;
+        let mut ep_in: Option<u8> = None;
+        let mut ep_out: Option<u8> = None;
+        for ias in interface.descriptors() {
+            for ep in ias
+                .endpoints()
+                .filter(|e| e.transfer_type() == TransferType::Bulk)
+            {
+                match ep.direction() {
+                    Direction::Out => {
+                        mps = Some(match mps.take() {
+                            Some(old) => old.min(ep.max_packet_size()),
+                            None => ep.max_packet_size(),
+                        });
+                        ep_out = Some(ep.address());
+                    }
+                    Direction::In => ep_in = Some(ep.address()),
+                }
+            }
+        }
+
+        if let Some(max_packet_size) = &mps {
+            tracing::debug!(max_packet_size, "Detected max packet size");
+        } else {
+            tracing::warn!("Unable to detect Max Packet Size!");
+        };
+
+        let ep_out = ep_out.ok_or("Failed to find OUT EP")?;
+        tracing::debug!("OUT EP: {ep_out}");
+
+        let ep_in = ep_in.ok_or("Failed to find IN EP")?;
+        tracing::debug!("IN EP: {ep_in}");
+
+        let boq = interface
+            .endpoint(ep_out)
+            .map_err(|e| format!("Failed to open OUT EP: {e:?}"))?;
+        let biq = interface
+            .endpoint(ep_in)
+            .map_err(|e| format!("Failed to open IN EP: {e:?}"))?;
+
+        Ok(HostClient::new_with_wire(
+            NusbWireTx {
+                boq,
+                max_packet_size: mps,
+            },
+            NusbWireRx {
+                biq,
+                consecutive_errs: 0,
+            },
+            NusbSpawn,
+            seq_no_kind,
+            err_uri_path,
+            outgoing_depth,
+        ))
+    }
+
+    /// Alias for [`new_raw_nusb_0_2`] if `raw-nusb-0_1` feature is not enabled.
+    #[cfg(not(feature = "raw-nusb-0_1"))]
+    #[inline]
+    pub fn new_raw_nusb<F: FnMut(&DeviceInfo) -> bool>(
+        func: F,
+        err_uri_path: &str,
+        outgoing_depth: usize,
+        seq_no_kind: VarSeqKind,
+    ) -> Self {
+        Self::new_raw_nusb_0_2(func, err_uri_path, outgoing_depth, seq_no_kind)
+    }
+
+    /// Create a new link using [`nusb`] for connectivity
+    ///
+    /// Panics if connection fails. See [`Self::try_new_raw_nusb_0_2()`] for more details.
+    ///
+    /// This constructor is available when the `raw-nusb` feature is enabled.
+    ///
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// use postcard_rpc::host_client::HostClient;
+    /// use postcard_rpc::header::VarSeqKind;
+    /// use serde::{Serialize, Deserialize};
+    /// use postcard_schema::Schema;
+    ///
+    /// /// A "wire error" type your server can use to respond to any
+    /// /// kind of request, for example if deserializing a request fails
+    /// #[derive(Debug, PartialEq, Schema, Serialize, Deserialize)]
+    /// pub enum Error {
+    ///    SomethingBad
+    /// }
+    ///
+    /// let client = HostClient::<Error>::new_raw_nusb_0_2(
+    ///     // Find the first device with the serial 12345678
+    ///     |d| d.serial_number() == Some("12345678"),
+    ///     // the URI/path for `Error` messages
+    ///     "error",
+    ///     // Outgoing queue depth in messages
+    ///     8,
+    ///     // Use one-byte sequence numbers
+    ///     VarSeqKind::Seq1,
+    /// );
+    /// ```
+    pub fn new_raw_nusb_0_2<F: FnMut(&DeviceInfo) -> bool>(
+        func: F,
+        err_uri_path: &str,
+        outgoing_depth: usize,
+        seq_no_kind: VarSeqKind,
+    ) -> Self {
+        Self::try_new_raw_nusb_0_2(func, err_uri_path, outgoing_depth, seq_no_kind)
+            .expect("should have found nusb device")
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Wire Interface Implementation
+//////////////////////////////////////////////////////////////////////////////
+
+/// NUSB Wire Interface Implementor
+///
+/// Uses Tokio for spawning tasks
+struct NusbSpawn;
+
+impl WireSpawn for NusbSpawn {
+    fn spawn(&mut self, fut: impl Future<Output = ()> + Send + 'static) {
+        // Explicitly drop the joinhandle as it impls Future and this makes
+        // clippy mad if you just let it drop implicitly
+        core::mem::drop(tokio::task::spawn(fut));
+    }
+}
+
+/// NUSB Wire Transmit Interface Implementor
+struct NusbWireTx {
+    boq: Endpoint<transfer::Bulk, transfer::Out>,
+    max_packet_size: Option<usize>,
+}
+
+#[derive(thiserror::Error, Debug)]
+enum NusbWireTxError {
+    #[error("Transfer Error on Send")]
+    Transfer(#[from] TransferError),
+}
+
+impl WireTx for NusbWireTx {
+    type Error = NusbWireTxError;
+
+    #[inline]
+    fn send(&mut self, data: Vec<u8>) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.send_inner(data)
+    }
+}
+
+impl NusbWireTx {
+    async fn send_inner(&mut self, data: Vec<u8>) -> Result<(), NusbWireTxError> {
+        let needs_zlp = if let Some(mps) = self.max_packet_size {
+            (data.len() % mps) == 0
+        } else {
+            true
+        };
+
+        self.boq.submit(data.into());
+
+        // Append ZLP if we are a multiple of max packet
+        if needs_zlp {
+            let vec: Vec<u8> = vec![];
+            self.boq.submit(vec.into());
+        }
+
+        let send_res = self.boq.next_complete().await;
+        if let Err(e) = send_res.status {
+            tracing::error!("Output Queue Error: {e:?}");
+            return Err(e.into());
+        }
+
+        if needs_zlp {
+            let send_res = self.boq.next_complete().await;
+            if let Err(e) = send_res.status {
+                tracing::error!("Output Queue Error: {e:?}");
+                return Err(e.into());
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// NUSB Wire Receive Interface Implementor
+struct NusbWireRx {
+    biq: Endpoint<transfer::Bulk, transfer::In>,
+    consecutive_errs: usize,
+}
+
+#[derive(thiserror::Error, Debug)]
+enum NusbWireRxError {
+    #[error("Transfer Error on Recv")]
+    Transfer(#[from] TransferError),
+}
+
+impl WireRx for NusbWireRx {
+    type Error = NusbWireRxError;
+
+    #[inline]
+    fn receive(&mut self) -> impl Future<Output = Result<Vec<u8>, Self::Error>> + Send {
+        self.recv_inner()
+    }
+}
+
+impl NusbWireRx {
+    async fn recv_inner(&mut self) -> Result<Vec<u8>, NusbWireRxError> {
+        loop {
+            // Rehydrate the queue
+            let pending = self.biq.pending();
+            for _ in 0..(IN_FLIGHT_REQS.saturating_sub(pending)) {
+                self.biq.submit(Buffer::new(MAX_TRANSFER_SIZE));
+            }
+
+            let res = self.biq.next_complete().await;
+
+            if let Err(e) = res.status {
+                self.consecutive_errs += 1;
+
+                tracing::error!(
+                    "In Worker error: {e:?}, consecutive: {}",
+                    self.consecutive_errs
+                );
+
+                // Docs only recommend this for Stall, but it seems to work with
+                // UNKNOWN on MacOS as well, todo: look into why!
+                //
+                // Update: This stall condition seems to have been due to an errata in the
+                // STM32F4 USB hardware. See https://github.com/embassy-rs/embassy/pull/2823
+                //
+                // It is now questionable whether we should be doing this stall recovery at all,
+                // as it likely indicates an issue with the connected USB device
+                let recoverable = match e {
+                    TransferError::Stall | TransferError::Unknown(_) => {
+                        self.consecutive_errs <= MAX_STALL_RETRIES
+                    }
+                    TransferError::Cancelled => false,
+                    TransferError::Disconnected => false,
+                    TransferError::Fault => false,
+                    TransferError::InvalidArgument => false,
+                };
+
+                let fatal = if recoverable {
+                    tracing::warn!("Attempting stall recovery!");
+
+                    // Stall recovery shouldn't be used with in-flight requests, so
+                    // cancel them all. They'll still pop out of next_complete.
+                    self.biq.cancel_all();
+                    tracing::info!("Cancelled all in-flight requests");
+
+                    // Now we need to join all in flight requests
+                    for _ in 0..(IN_FLIGHT_REQS - 1) {
+                        let res = self.biq.next_complete().await;
+                        tracing::info!("Drain state: {:?}", res.status);
+                    }
+
+                    // Now we can mark the stall as clear
+                    match self.biq.clear_halt().wait() {
+                        Ok(()) => false,
+                        Err(e) => {
+                            tracing::error!("Failed to clear stall: {e:?}, Fatal.");
+                            true
+                        }
+                    }
+                } else {
+                    tracing::error!(
+                        "Giving up after {} errors in a row, final error: {e:?}",
+                        self.consecutive_errs
+                    );
+                    true
+                };
+
+                if fatal {
+                    tracing::error!("Fatal Error, exiting");
+                    // When we close the channel, all pending receivers and subscribers
+                    // will be notified
+                    return Err(e.into());
+                } else {
+                    tracing::info!("Potential recovery, resuming NusbWireRx::recv_inner");
+                    continue;
+                }
+            }
+
+            // If we get a good decode, clear the error flag
+            if self.consecutive_errs != 0 {
+                tracing::info!("Clearing consecutive error counter after good header decode");
+                self.consecutive_errs = 0;
+            }
+
+            return Ok(res.buffer.into_vec());
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a feature to add `nusb v0.2` support. 

Quick summary:

- New `raw-nusb-0_2` feature.
- Previous `raw-nusb` feature is still available and points to `raw-nusb-0_1`.
- If both features are activated at the same time, `HostClient` impls are renamed to the specific feature, i.e., `try_new_raw_nusb_0_1`
- If only one feature is activated, `HostClient` impls w/o the `0_x` exist that point to the `0_x` version, i.e., `try_new_raw_nusb` would point to `try_new_raw_nusb_0_1` if only `raw-nusb-0_1` is activated. This ensures compatibility with current setups, i.e., if `raw-nusb` is activated this points to `raw-nusb-0_1` now, which is the same as the existing version, and, since it's the only `nusb` feature activated, it will automatically make the existing impls available. 
- The majority of `raw-nusb-0_2` support is copied from the `0_1` version and adjusted to work with the new API

Opening this so it's easier to spot the differences, would be great to hear your opinion. Especially: could the aliasing be done in a nicer way?