### PR TITLE
Fixed incorrect doc comment.

### DIFF
--- a/source/postcard-rpc/src/lib.rs
+++ b/source/postcard-rpc/src/lib.rs
@@ -147,7 +147,7 @@ pub mod test_utils;
 pub use postcard_schema::key::hash;
 pub use postcard_schema::key::Key;
 
-/// A compacted 2-byte key
+/// A compacted 1-byte key
 ///
 /// This is defined specifically as the following conversion:
 ///


### PR DESCRIPTION
Key1 said "2-byte key" instead of "1-byte key"

(I don't do this often so i hope i did the pull-request stuff properly.)