### PR TITLE
Use signed sequence numbers

### DIFF
--- a/book/src/comms-postcard-rpc.md
+++ b/book/src/comms-postcard-rpc.md
@@ -123,7 +123,7 @@ How does `postcard-rpc` help us determine which is which?
 At the front of every message, we add a header with two fields:
 
 1. a Key, explained below
-2. a Sequence Number (a `u32`)
+2. a Sequence Number (a signed integer)
 
 ### Keys
 
@@ -155,9 +155,18 @@ This is important for two reasons:
 
 ### Sequence Numbers
 
-Since we might have multiple requests "In Flight" at one time, we use an incrementing sequence
-number to each request. This lets us tell which response goes with each request, even if they
-arrive out of order.
+Since we might have multiple requests "In Flight" at one time, we attach a sequence number to
+each request. This lets us tell which response goes with each request, even if they arrive out
+of order.
+
+Sequence numbers are signed, and the sign shows who _chose_ the number:
+
+* The client chooses a **positive** sequence number for the requests (and topics) it sends
+* The server chooses a **negative** sequence number for the topics (and logs) it sends
+* An endpoint **reply** reuses the sequence number from the matching request, so the host can
+  pair them up even when replies come back out of order
+
+On the wire, that sequence number is 1, 2, or 4 bytes of little-endian two's-complement.
 
 For example:
 

--- a/source/postcard-rpc-test/tests/subscrobble.rs
+++ b/source/postcard-rpc-test/tests/subscrobble.rs
@@ -266,15 +266,15 @@ async fn exclusive_subs_work() {
     #[allow(deprecated)]
     let mut sub = cli.subscribe::<ZetaTopic10>(16).await.unwrap();
     server_sender
-        .publish::<ZetaTopic10>(VarSeq::Seq4(1), &ZMsg(10))
+        .publish::<ZetaTopic10>(VarSeq::Seq4(-1), &ZMsg(10))
         .await
         .unwrap();
     server_sender
-        .publish::<ZetaTopic10>(VarSeq::Seq4(2), &ZMsg(20))
+        .publish::<ZetaTopic10>(VarSeq::Seq4(-2), &ZMsg(20))
         .await
         .unwrap();
     server_sender
-        .publish::<ZetaTopic10>(VarSeq::Seq4(3), &ZMsg(30))
+        .publish::<ZetaTopic10>(VarSeq::Seq4(-3), &ZMsg(30))
         .await
         .unwrap();
     let get_fut = async move {
@@ -288,15 +288,15 @@ async fn exclusive_subs_work() {
     #[allow(deprecated)]
     let mut sub2 = cli.subscribe::<ZetaTopic10>(16).await.unwrap();
     server_sender
-        .publish::<ZetaTopic10>(VarSeq::Seq4(1), &ZMsg(11))
+        .publish::<ZetaTopic10>(VarSeq::Seq4(-1), &ZMsg(11))
         .await
         .unwrap();
     server_sender
-        .publish::<ZetaTopic10>(VarSeq::Seq4(2), &ZMsg(21))
+        .publish::<ZetaTopic10>(VarSeq::Seq4(-2), &ZMsg(21))
         .await
         .unwrap();
     server_sender
-        .publish::<ZetaTopic10>(VarSeq::Seq4(3), &ZMsg(31))
+        .publish::<ZetaTopic10>(VarSeq::Seq4(-3), &ZMsg(31))
         .await
         .unwrap();
     // Ensure the sender has a chance to send the messages
@@ -312,15 +312,15 @@ async fn exclusive_subs_work() {
     };
     let _: () = timeout(Duration::from_millis(100), get_fut).await.unwrap();
     server_sender
-        .publish::<ZetaTopic10>(VarSeq::Seq4(1), &ZMsg(12))
+        .publish::<ZetaTopic10>(VarSeq::Seq4(-1), &ZMsg(12))
         .await
         .unwrap();
     server_sender
-        .publish::<ZetaTopic10>(VarSeq::Seq4(2), &ZMsg(22))
+        .publish::<ZetaTopic10>(VarSeq::Seq4(-2), &ZMsg(22))
         .await
         .unwrap();
     server_sender
-        .publish::<ZetaTopic10>(VarSeq::Seq4(3), &ZMsg(32))
+        .publish::<ZetaTopic10>(VarSeq::Seq4(-3), &ZMsg(32))
         .await
         .unwrap();
     let get_fut = async move {
@@ -336,15 +336,15 @@ async fn exclusive_subs_work() {
     let mut sub5 = cli.subscribe_multi::<ZetaTopic10>(16).await.unwrap();
     sleep(Duration::from_millis(10)).await;
     server_sender
-        .publish::<ZetaTopic10>(VarSeq::Seq4(1), &ZMsg(15))
+        .publish::<ZetaTopic10>(VarSeq::Seq4(-1), &ZMsg(15))
         .await
         .unwrap();
     server_sender
-        .publish::<ZetaTopic10>(VarSeq::Seq4(2), &ZMsg(25))
+        .publish::<ZetaTopic10>(VarSeq::Seq4(-2), &ZMsg(25))
         .await
         .unwrap();
     server_sender
-        .publish::<ZetaTopic10>(VarSeq::Seq4(3), &ZMsg(35))
+        .publish::<ZetaTopic10>(VarSeq::Seq4(-3), &ZMsg(35))
         .await
         .unwrap();
     // Ensure the sender has a chance to send the messages
@@ -406,15 +406,15 @@ async fn broadcast_subs_work() {
     let mut sub1 = cli.subscribe_multi::<ZetaTopic10>(16).await.unwrap();
     let mut sub2 = cli.subscribe_multi::<ZetaTopic10>(16).await.unwrap();
     server_sender
-        .publish::<ZetaTopic10>(VarSeq::Seq4(1), &ZMsg(10))
+        .publish::<ZetaTopic10>(VarSeq::Seq4(-1), &ZMsg(10))
         .await
         .unwrap();
     server_sender
-        .publish::<ZetaTopic10>(VarSeq::Seq4(2), &ZMsg(20))
+        .publish::<ZetaTopic10>(VarSeq::Seq4(-2), &ZMsg(20))
         .await
         .unwrap();
     server_sender
-        .publish::<ZetaTopic10>(VarSeq::Seq4(3), &ZMsg(30))
+        .publish::<ZetaTopic10>(VarSeq::Seq4(-3), &ZMsg(30))
         .await
         .unwrap();
     let get_fut1 = async move {
@@ -436,15 +436,15 @@ async fn broadcast_subs_work() {
     #[allow(deprecated)]
     let mut sub5 = cli.subscribe::<ZetaTopic10>(16).await.unwrap();
     server_sender
-        .publish::<ZetaTopic10>(VarSeq::Seq4(1), &ZMsg(10))
+        .publish::<ZetaTopic10>(VarSeq::Seq4(-1), &ZMsg(10))
         .await
         .unwrap();
     server_sender
-        .publish::<ZetaTopic10>(VarSeq::Seq4(2), &ZMsg(20))
+        .publish::<ZetaTopic10>(VarSeq::Seq4(-2), &ZMsg(20))
         .await
         .unwrap();
     server_sender
-        .publish::<ZetaTopic10>(VarSeq::Seq4(3), &ZMsg(30))
+        .publish::<ZetaTopic10>(VarSeq::Seq4(-3), &ZMsg(30))
         .await
         .unwrap();
     let get_fut1 = async move {

--- a/source/postcard-rpc/src/header.rs
+++ b/source/postcard-rpc/src/header.rs
@@ -45,11 +45,17 @@
 //!
 //! ## Sequence Number
 //!
-//! The Sequence Number is an unsigned integer used to match request-response pairs,
-//! and disambiguate between multiple in-flight messages.
+//! The Sequence Number is a signed integer used to match request-response pairs,
+//! disambiguate between multiple in-flight messages, and encode who originated
+//! a message:
+//!
+//! * Positive sequence numbers are chosen by the client
+//! * Negative sequence numbers are chosen by the server
+//!
+//! Endpoint replies reuse the sequence number from the matching request.
 //!
 //! Sequence Numbers may be encoded with variable fidelity on the wire, always in
-//! little-endian order, of 1, 2, or 4 bytes.
+//! little-endian two's-complement order, of 1, 2, or 4 bytes.
 //!
 //! The length of the Sequence Number is determined by the two `MM` bits in the
 //! discriminant.
@@ -234,57 +240,79 @@ pub enum VarKeyKind {
 ///
 /// We DO NOT impl Serialize/Deserialize for this type because we use
 /// non-postcard-compatible format (externally tagged)
+///
+/// Sequence numbers are signed: positive values are chosen by the client,
+/// and negative values are chosen by the server. Endpoint replies reuse
+/// the request's sequence number.
 #[derive(Debug, Clone, Copy)]
 pub enum VarSeq {
     /// A one byte sequence number
-    Seq1(u8),
+    Seq1(i8),
     /// A two byte sequence number
-    Seq2(u16),
+    Seq2(i16),
     /// A four byte sequence number
-    Seq4(u32),
+    Seq4(i32),
+}
+
+impl From<i8> for VarSeq {
+    fn from(value: i8) -> Self {
+        Self::Seq1(value)
+    }
+}
+
+impl From<i16> for VarSeq {
+    fn from(value: i16) -> Self {
+        Self::Seq2(value)
+    }
+}
+
+impl From<i32> for VarSeq {
+    fn from(value: i32) -> Self {
+        Self::Seq4(value)
+    }
 }
 
 impl From<u8> for VarSeq {
     fn from(value: u8) -> Self {
-        Self::Seq1(value)
+        Self::Seq1(value as i8)
     }
 }
 
 impl From<u16> for VarSeq {
     fn from(value: u16) -> Self {
-        Self::Seq2(value)
+        Self::Seq2(value as i16)
     }
 }
 
 impl From<u32> for VarSeq {
     fn from(value: u32) -> Self {
-        Self::Seq4(value)
+        Self::Seq4(value as i32)
     }
 }
 
-impl Into<u8> for VarSeq {
-    fn into(self) -> u8 {
-        match self {
+impl From<VarSeq> for i8 {
+    fn from(value: VarSeq) -> Self {
+        match value {
             VarSeq::Seq1(v) => v,
-            VarSeq::Seq2(v) => v as u8,
-            VarSeq::Seq4(v) => v as u8,
+            VarSeq::Seq2(v) => v as i8,
+            VarSeq::Seq4(v) => v as i8,
         }
     }
 }
 
-impl Into<u16> for VarSeq {
-    fn into(self) -> u16 {
-        match self {
+impl From<VarSeq> for i16 {
+    fn from(value: VarSeq) -> Self {
+        match value {
             VarSeq::Seq1(v) => v.into(),
             VarSeq::Seq2(v) => v,
-            VarSeq::Seq4(v) => v as u16,
+            VarSeq::Seq4(v) => v as i16,
         }
     }
 }
 
-impl Into<u32> for VarSeq {
-    fn into(self) -> u32 {
-        match self {
+impl From<VarSeq> for i32 {
+    fn from(value: VarSeq) -> Self {
+        match value {
             VarSeq::Seq1(v) => v.into(),
             VarSeq::Seq2(v) => v.into(),
             VarSeq::Seq4(v) => v,
@@ -294,18 +322,40 @@ impl Into<u32> for VarSeq {
 
 impl PartialEq for VarSeq {
     fn eq(&self, other: &Self) -> bool {
-        Into::<u32>::into(*self) == Into::<u32>::into(*other)
+        i32::from(*self) == i32::from(*other)
     }
 }
 
 impl VarSeq {
+    /// The next positive client sequence number after `n`.
+    ///
+    /// Wraps [`i32::MAX`] to `1` so the result stays positive.
+    pub const fn wrapping_add_positive(n: i32) -> i32 {
+        if n >= i32::MAX {
+            1
+        } else {
+            n + 1
+        }
+    }
+
+    /// The next negative server sequence number after `n`.
+    ///
+    /// Wraps [`i32::MIN`] to `-1` so the result stays negative.
+    pub const fn wrapping_add_negative(n: i32) -> i32 {
+        if n <= i32::MIN {
+            -1
+        } else {
+            n - 1
+        }
+    }
+
     /// Resize (up or down) to the requested kind.
     ///
-    /// When increasing size, the number is left-extended, e.g. `0x42u8` becomes
-    /// `0x0000_0042u32` when resizing 1 -> 4.
+    /// When increasing size, the number is sign-extended, e.g. `-1i8` becomes
+    /// `-1i32` when resizing 1 -> 4.
     ///
-    /// When decreasing size, the number is truncated, e.g. `0xABCD_EF12u32`
-    /// becomes `0x12u8` when resizing 4 -> 1.
+    /// When decreasing size, the number is truncated, e.g. `0x1234_5678i32`
+    /// becomes `0x78i8` when resizing 4 -> 1.
     pub fn resize(&mut self, kind: VarSeqKind) {
         match (&self, kind) {
             (VarSeq::Seq1(_), VarSeqKind::Seq1) => {}
@@ -318,16 +368,16 @@ impl VarSeq {
                 *self = VarSeq::Seq4((*s).into());
             }
             (VarSeq::Seq2(s), VarSeqKind::Seq1) => {
-                *self = VarSeq::Seq1((*s) as u8);
+                *self = VarSeq::Seq1(*s as i8);
             }
             (VarSeq::Seq2(s), VarSeqKind::Seq4) => {
                 *self = VarSeq::Seq4((*s).into());
             }
             (VarSeq::Seq4(s), VarSeqKind::Seq1) => {
-                *self = VarSeq::Seq1((*s) as u8);
+                *self = VarSeq::Seq1(*s as i8);
             }
             (VarSeq::Seq4(s), VarSeqKind::Seq2) => {
-                *self = VarSeq::Seq2((*s) as u16);
+                *self = VarSeq::Seq2(*s as i16);
             }
         }
     }
@@ -423,7 +473,7 @@ impl VarHeader {
         match &self.seq_no {
             VarSeq::Seq1(s) => {
                 disc_out |= Self::SEQ_ONE_BITS;
-                out.push(*s);
+                out.push(*s as u8);
             }
             VarSeq::Seq2(s) => {
                 disc_out |= Self::SEQ_TWO_BITS;
@@ -486,7 +536,7 @@ impl VarHeader {
             VarSeq::Seq1(s) => {
                 *disc_out |= Self::SEQ_ONE_BITS;
                 let (seqbs, _) = remain.split_first_mut()?;
-                *seqbs = *s;
+                *seqbs = *s as u8;
                 used += 1;
             }
             VarSeq::Seq2(s) => {
@@ -553,21 +603,21 @@ impl VarHeader {
             Self::SEQ_ONE_BITS => {
                 let (seqbs, remain3) = remain.split_first()?;
                 remain = remain3;
-                VarSeq::Seq1(*seqbs)
+                VarSeq::Seq1(*seqbs as i8)
             }
             Self::SEQ_TWO_BITS => {
                 let (seqbs, remain3) = remain.split_at_checked(2)?;
                 remain = remain3;
                 let mut buf = [0u8; 2];
                 buf.copy_from_slice(seqbs);
-                VarSeq::Seq2(u16::from_le_bytes(buf))
+                VarSeq::Seq2(i16::from_le_bytes(buf))
             }
             Self::SEQ_FOUR_BITS => {
                 let (seqbs, remain3) = remain.split_at_checked(4)?;
                 remain = remain3;
                 let mut buf = [0u8; 4];
                 buf.copy_from_slice(seqbs);
-                VarSeq::Seq4(u32::from_le_bytes(buf))
+                VarSeq::Seq4(i32::from_le_bytes(buf))
             }
             // Possible (could be 0b11), is invalid
             _ => return None,
@@ -671,17 +721,29 @@ mod test {
     #[test]
     fn var_seq_equality() {
         let val32 = 0x12345678;
-        let val16 = 0x9abc;
-        let val8 = 0xde;
+        let val16 = 0x1abc;
+        let val8 = 0x5e;
 
         assert_eq!(VarSeq::Seq1(val8), VarSeq::Seq1(val8));
         assert_eq!(VarSeq::Seq1(val8), VarSeq::Seq2(val8.into()));
         assert_eq!(VarSeq::Seq1(val8), VarSeq::Seq4(val8.into()));
-        assert_ne!(VarSeq::Seq2(val16), VarSeq::Seq1(val16 as u8));
+        assert_ne!(VarSeq::Seq2(val16), VarSeq::Seq1(val16 as i8));
         assert_eq!(VarSeq::Seq2(val16), VarSeq::Seq2(val16));
         assert_eq!(VarSeq::Seq2(val16), VarSeq::Seq4(val16.into()));
-        assert_ne!(VarSeq::Seq4(val32), VarSeq::Seq1(val32 as u8));
-        assert_ne!(VarSeq::Seq4(val32), VarSeq::Seq2(val32 as u16));
+        assert_ne!(VarSeq::Seq4(val32), VarSeq::Seq1(val32 as i8));
+        assert_ne!(VarSeq::Seq4(val32), VarSeq::Seq2(val32 as i16));
         assert_eq!(VarSeq::Seq4(val32), VarSeq::Seq4(val32));
+
+        assert_eq!(VarSeq::Seq1(-1), VarSeq::Seq2(-1));
+        assert_eq!(VarSeq::Seq1(-1), VarSeq::Seq4(-1));
+    }
+
+    #[test]
+    fn var_seq_wrapping_keeps_sign() {
+        assert_eq!(VarSeq::wrapping_add_positive(42), 43);
+        assert_eq!(VarSeq::wrapping_add_positive(i32::MAX), 1);
+
+        assert_eq!(VarSeq::wrapping_add_negative(-42), -43);
+        assert_eq!(VarSeq::wrapping_add_negative(i32::MIN), -1);
     }
 }

--- a/source/postcard-rpc/src/host_client/mod.rs
+++ b/source/postcard-rpc/src/host_client/mod.rs
@@ -9,7 +9,7 @@ use std::{
     future::Future,
     marker::PhantomData,
     sync::{
-        atomic::{AtomicU32, Ordering},
+        atomic::{AtomicI32, Ordering},
         Arc, RwLock,
     },
 };
@@ -201,7 +201,7 @@ where
         let ctx = Arc::new(HostContext {
             kkind: RwLock::new(VarKeyKind::Key8),
             map: WaitMap::new(),
-            seq: AtomicU32::new(0),
+            seq: AtomicI32::new(1),
             subscription_timeout: config.subscriber_timeout_if_full,
         });
 
@@ -343,7 +343,11 @@ where
         E::Request: Serialize + Schema,
         E::Response: DeserializeOwned + Schema,
     {
-        let seq_no = self.ctx.seq.fetch_add(1, Ordering::Relaxed);
+        let seq_no = self.ctx.seq.update(
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+            VarSeq::wrapping_add_positive,
+        );
 
         let msg = postcard::to_stdvec(&t).expect("Allocations should not ever fail");
         let frame = RpcFrame {
@@ -934,7 +938,7 @@ impl RpcFrame {
 pub struct HostContext {
     kkind: RwLock<VarKeyKind>,
     map: WaitMap<VarHeader, (VarHeader, Vec<u8>)>,
-    seq: AtomicU32,
+    seq: AtomicI32,
     subscription_timeout: Duration,
 }
 

--- a/source/postcard-rpc/src/server/impls/embassy_usb_v0_5.rs
+++ b/source/postcard-rpc/src/server/impls/embassy_usb_v0_5.rs
@@ -157,7 +157,7 @@ pub mod dispatch_impl {
 
             let wtx = self.cell.init(Mutex::new(EUsbWireTxInner {
                 ep_in,
-                log_seq: 0,
+                log_seq: -1,
                 tx_buf,
                 pending_frame: false,
                 timeout_ms_per_frame: DEFAULT_TIMEOUT_MS_PER_FRAME,
@@ -231,7 +231,7 @@ pub mod dispatch_impl {
 
             let wtx = self.cell.init(Mutex::new(EUsbWireTxInner {
                 ep_in,
-                log_seq: 0,
+                log_seq: -1,
                 tx_buf,
                 pending_frame: false,
                 timeout_ms_per_frame: DEFAULT_TIMEOUT_MS_PER_FRAME,
@@ -250,7 +250,7 @@ pub mod dispatch_impl {
 /// Implementation detail, holding the endpoint and scratch buffer used for sending
 pub struct EUsbWireTxInner<D: Driver<'static>> {
     ep_in: D::EndpointIn,
-    log_seq: u16,
+    log_seq: i16,
     tx_buf: &'static mut [u8],
     pending_frame: bool,
     timeout_ms_per_frame: usize,
@@ -384,7 +384,7 @@ impl<M: RawMutex + 'static, D: Driver<'static> + 'static> WireTx for EUsbWireTx<
             VarKeyKind::Key8 => VarKey::Key8(LoggingTopic::TOPIC_KEY),
         };
         let ctr = *log_seq;
-        *log_seq = log_seq.wrapping_add(1);
+        *log_seq = if ctr == i16::MIN { -1 } else { ctr - 1 };
         let wh = VarHeader {
             key,
             seq_no: VarSeq::Seq2(ctr),
@@ -432,7 +432,7 @@ impl<M: RawMutex + 'static, D: Driver<'static> + 'static> WireTx for EUsbWireTx<
             VarKeyKind::Key8 => VarKey::Key8(LoggingTopic::TOPIC_KEY),
         };
         let ctr = *log_seq;
-        *log_seq = log_seq.wrapping_add(1);
+        *log_seq = if ctr == i16::MIN { -1 } else { ctr - 1 };
         let wh = VarHeader {
             key,
             seq_no: VarSeq::Seq2(ctr),

--- a/source/postcard-rpc/src/server/impls/embassy_usb_v0_6.rs
+++ b/source/postcard-rpc/src/server/impls/embassy_usb_v0_6.rs
@@ -157,7 +157,7 @@ pub mod dispatch_impl {
 
             let wtx = self.cell.init(Mutex::new(EUsbWireTxInner {
                 ep_in,
-                log_seq: 0,
+                log_seq: -1,
                 tx_buf,
                 pending_frame: false,
                 timeout_ms_per_frame: DEFAULT_TIMEOUT_MS_PER_FRAME,
@@ -231,7 +231,7 @@ pub mod dispatch_impl {
 
             let wtx = self.cell.init(Mutex::new(EUsbWireTxInner {
                 ep_in,
-                log_seq: 0,
+                log_seq: -1,
                 tx_buf,
                 pending_frame: false,
                 timeout_ms_per_frame: DEFAULT_TIMEOUT_MS_PER_FRAME,
@@ -250,7 +250,7 @@ pub mod dispatch_impl {
 /// Implementation detail, holding the endpoint and scratch buffer used for sending
 pub struct EUsbWireTxInner<D: Driver<'static>> {
     ep_in: D::EndpointIn,
-    log_seq: u16,
+    log_seq: i16,
     tx_buf: &'static mut [u8],
     pending_frame: bool,
     timeout_ms_per_frame: usize,
@@ -384,7 +384,7 @@ impl<M: RawMutex + 'static, D: Driver<'static> + 'static> WireTx for EUsbWireTx<
             VarKeyKind::Key8 => VarKey::Key8(LoggingTopic::TOPIC_KEY),
         };
         let ctr = *log_seq;
-        *log_seq = log_seq.wrapping_add(1);
+        *log_seq = if ctr == i16::MIN { -1 } else { ctr - 1 };
         let wh = VarHeader {
             key,
             seq_no: VarSeq::Seq2(ctr),
@@ -432,7 +432,7 @@ impl<M: RawMutex + 'static, D: Driver<'static> + 'static> WireTx for EUsbWireTx<
             VarKeyKind::Key8 => VarKey::Key8(LoggingTopic::TOPIC_KEY),
         };
         let ctr = *log_seq;
-        *log_seq = log_seq.wrapping_add(1);
+        *log_seq = if ctr == i16::MIN { -1 } else { ctr - 1 };
         let wh = VarHeader {
             key,
             seq_no: VarSeq::Seq2(ctr),

--- a/source/postcard-rpc/src/server/impls/embedded_io_async_v0_6.rs
+++ b/source/postcard-rpc/src/server/impls/embedded_io_async_v0_6.rs
@@ -69,7 +69,7 @@ pub struct EioWireRx<R: Read> {
 struct EioWireTxInner<Tx: Write> {
     t: Tx,
     tx_buf: &'static mut [u8],
-    log_seq: u16,
+    log_seq: i16,
 }
 
 // ----- IMPLS -----
@@ -94,7 +94,7 @@ impl<Rx: Read, Tx: Write, M: RawMutex + 'static, const RXB: usize, const TXB: us
         let txi = self.tx.try_init(Mutex::new(EioWireTxInner {
             t,
             tx_buf: txb,
-            log_seq: 0,
+            log_seq: -1,
         }))?;
         let rx = EioWireRx {
             remain: rxb,
@@ -201,7 +201,7 @@ where
             VarKeyKind::Key8 => VarKey::Key8(LoggingTopic::TOPIC_KEY),
         };
         let ctr = *log_seq;
-        *log_seq = log_seq.wrapping_add(1);
+        *log_seq = if ctr == i16::MIN { -1 } else { ctr - 1 };
         let wh = VarHeader {
             key,
             seq_no: VarSeq::Seq2(ctr),

--- a/source/postcard-rpc/src/server/impls/embedded_io_async_v0_7.rs
+++ b/source/postcard-rpc/src/server/impls/embedded_io_async_v0_7.rs
@@ -69,7 +69,7 @@ pub struct EioWireRx<R: Read> {
 struct EioWireTxInner<Tx: Write> {
     t: Tx,
     tx_buf: &'static mut [u8],
-    log_seq: u16,
+    log_seq: i16,
 }
 
 // ----- IMPLS -----
@@ -94,7 +94,7 @@ impl<Rx: Read, Tx: Write, M: RawMutex + 'static, const RXB: usize, const TXB: us
         let txi = self.tx.try_init(Mutex::new(EioWireTxInner {
             t,
             tx_buf: txb,
-            log_seq: 0,
+            log_seq: -1,
         }))?;
         let rx = EioWireRx {
             remain: rxb,
@@ -201,7 +201,7 @@ where
             VarKeyKind::Key8 => VarKey::Key8(LoggingTopic::TOPIC_KEY),
         };
         let ctr = *log_seq;
-        *log_seq = log_seq.wrapping_add(1);
+        *log_seq = if ctr == i16::MIN { -1 } else { ctr - 1 };
         let wh = VarHeader {
             key,
             seq_no: VarSeq::Seq2(ctr),

--- a/source/postcard-rpc/src/server/impls/test_channels.rs
+++ b/source/postcard-rpc/src/server/impls/test_channels.rs
@@ -3,7 +3,7 @@
 use core::{
     convert::Infallible,
     future::{pending, Future},
-    sync::atomic::{AtomicU32, Ordering},
+    sync::atomic::{AtomicI32, Ordering},
 };
 use std::sync::Arc;
 
@@ -110,7 +110,7 @@ pub mod dispatch_impl {
 #[derive(Clone)]
 pub struct ChannelWireTx {
     tx: mpsc::Sender<Vec<u8>>,
-    log_ctr: Arc<AtomicU32>,
+    log_ctr: Arc<AtomicI32>,
     stopper: Option<Stopper>,
 }
 
@@ -119,7 +119,7 @@ impl ChannelWireTx {
     pub fn new(tx: mpsc::Sender<Vec<u8>>) -> Self {
         Self {
             tx,
-            log_ctr: Arc::new(AtomicU32::new(0)),
+            log_ctr: Arc::new(AtomicI32::new(-1)),
             stopper: None,
         }
     }
@@ -171,7 +171,11 @@ impl WireTx for ChannelWireTx {
     }
 
     async fn send_log_str(&self, kkind: VarKeyKind, s: &str) -> Result<(), Self::Error> {
-        let ctr = self.log_ctr.fetch_add(1, Ordering::Relaxed);
+        let ctr = self.log_ctr.update(
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+            VarSeq::wrapping_add_negative,
+        );
         let key = match kkind {
             VarKeyKind::Key1 => VarKey::Key1(LoggingTopic::TOPIC_KEY1),
             VarKeyKind::Key2 => VarKey::Key2(LoggingTopic::TOPIC_KEY2),
@@ -193,7 +197,11 @@ impl WireTx for ChannelWireTx {
         kkind: VarKeyKind,
         a: Arguments<'a>,
     ) -> Result<(), Self::Error> {
-        let ctr = self.log_ctr.fetch_add(1, Ordering::Relaxed);
+        let ctr = self.log_ctr.update(
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+            VarSeq::wrapping_add_negative,
+        );
         let key = match kkind {
             VarKeyKind::Key1 => VarKey::Key1(LoggingTopic::TOPIC_KEY1),
             VarKeyKind::Key2 => VarKey::Key2(LoggingTopic::TOPIC_KEY2),

--- a/source/postcard-rpc/src/server/impls/usb_gadget.rs
+++ b/source/postcard-rpc/src/server/impls/usb_gadget.rs
@@ -147,7 +147,7 @@ impl UsbGadgetWireTx {
     ) -> Self {
         let inner = UsbGadgetWireTxInner {
             ep_tx,
-            log_seq: 0,
+            log_seq: -1,
             tx_buf,
         };
 
@@ -161,7 +161,7 @@ impl UsbGadgetWireTx {
 #[derive(Debug)]
 struct UsbGadgetWireTxInner {
     ep_tx: EndpointSender,
-    log_seq: u16,
+    log_seq: i16,
     tx_buf: &'static mut [u8],
 }
 
@@ -236,7 +236,7 @@ impl WireTx for UsbGadgetWireTx {
                 VarKeyKind::Key8 => VarKey::Key8(LoggingTopic::TOPIC_KEY),
             };
             let ctr = *log_seq;
-            *log_seq = log_seq.wrapping_add(1);
+            *log_seq = if ctr == i16::MIN { -1 } else { ctr - 1 };
             let wh = VarHeader {
                 key,
                 seq_no: VarSeq::Seq2(ctr),
@@ -276,7 +276,7 @@ impl WireTx for UsbGadgetWireTx {
                 VarKeyKind::Key8 => VarKey::Key8(LoggingTopic::TOPIC_KEY),
             };
             let ctr = *log_seq;
-            *log_seq = log_seq.wrapping_add(1);
+            *log_seq = if ctr == i16::MIN { -1 } else { ctr - 1 };
             let wh = VarHeader {
                 key,
                 seq_no: VarSeq::Seq2(ctr),

--- a/source/postcard-rpc/src/server/mod.rs
+++ b/source/postcard-rpc/src/server/mod.rs
@@ -284,7 +284,15 @@ impl<Tx: WireTx> Sender<Tx> {
         use crate::standard_icd::SchemaData;
         use crate::standard_icd::{GetAllSchemaDataTopic, GetAllSchemasEndpoint, SchemaTotals};
 
-        let mut msg_ctr = 0;
+        fn next_msg(ctr: i16) -> i16 {
+            if ctr == i16::MIN {
+                -1
+            } else {
+                ctr - 1
+            }
+        }
+
+        let mut msg_ctr = -1;
         let mut err_ctr = 0;
 
         // First, send all types
@@ -298,7 +306,7 @@ impl<Tx: WireTx> Sender<Tx> {
             if res.is_err() {
                 err_ctr += 1;
             };
-            msg_ctr += 1;
+            msg_ctr = next_msg(msg_ctr);
         }
 
         // Then all endpoints
@@ -316,8 +324,7 @@ impl<Tx: WireTx> Sender<Tx> {
             if res.is_err() {
                 err_ctr += 1;
             }
-
-            msg_ctr += 1;
+            msg_ctr = next_msg(msg_ctr);
         }
 
         // Then output topics
@@ -335,7 +342,7 @@ impl<Tx: WireTx> Sender<Tx> {
             if res.is_err() {
                 err_ctr += 1;
             }
-            msg_ctr += 1;
+            msg_ctr = next_msg(msg_ctr);
         }
 
         // Then input topics
@@ -353,7 +360,7 @@ impl<Tx: WireTx> Sender<Tx> {
             if res.is_err() {
                 err_ctr += 1;
             }
-            msg_ctr += 1;
+            msg_ctr = next_msg(msg_ctr);
         }
 
         // Finally, reply with the totals

--- a/source/postcard-rpc/src/test_utils.rs
+++ b/source/postcard-rpc/src/test_utils.rs
@@ -61,7 +61,7 @@ impl LocalFakeServer {
         let frame = RpcFrame {
             header: VarHeader {
                 key: VarKey::Key8(E::RESP_KEY),
-                seq_no: VarSeq::Seq4(seq_no),
+                seq_no: VarSeq::Seq4(seq_no as i32),
             },
             body: postcard::to_stdvec(data).unwrap(),
         };
@@ -74,7 +74,7 @@ impl LocalFakeServer {
     /// Publish
     pub async fn publish<T: Topic>(
         &mut self,
-        seq_no: u32,
+        seq_no: i32,
         data: &T::Message,
     ) -> Result<(), LocalError>
     where


### PR DESCRIPTION
This way the server and client will never generate the same sequence number.