### PR TITLE
fix(usb-gadget): explicitly cancel the transfer if it times out or fails

### DIFF
--- a/example/server-usb-gadget/Cargo.lock
+++ b/example/server-usb-gadget/Cargo.lock
@@ -178,7 +178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -466,7 +466,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -651,7 +651,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -966,9 +966,9 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "usb-gadget"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7010a310d9c6caac0282c94a0ab830d7dec675bb62241553f681cc795e0f4d31"
+checksum = "a57f5767e127a41fefc1de7f55bfe707e1080de797ccf3e3089c7d35635cfd3a"
 dependencies = [
  "bitflags",
  "byteorder",

--- a/source/postcard-rpc/Cargo.toml
+++ b/source/postcard-rpc/Cargo.toml
@@ -176,7 +176,7 @@ optional = true
 
 [target.'cfg(target_os = "linux")'.dependencies.usb-gadget]
 package = "usb-gadget"
-version = "1.1"
+version = "1"
 optional = true
 
 [target.'cfg(target_os = "linux")'.dependencies.bytes]

--- a/source/postcard-rpc/src/server/impls/usb_gadget.rs
+++ b/source/postcard-rpc/src/server/impls/usb_gadget.rs
@@ -213,9 +213,19 @@ impl WireTx for UsbGadgetWireTx {
             Ok::<(), WireTxErrorKind>(())
         };
 
-        tokio::time::timeout(timeout, send)
-            .await
-            .or(Err(WireTxErrorKind::Timeout))?
+        let res = match tokio::time::timeout(timeout, send).await {
+            Ok(res) => res,
+            Err(_) => Err(WireTxErrorKind::Timeout),
+        };
+
+        // Timeout OR an underlying io::Error from send_async
+        // EndpointSender::send_async might return errors of previously enqueued send operations,
+        // so in any case it's better to try to clean up  to prevent future transfers from hanging
+        if res.is_err() {
+            let _ = ep_tx.cancel();
+        }
+
+        res
     }
 
     async fn send_log_str(


### PR DESCRIPTION
If the connection is interrupted (cable yanked, etc) the underlying usb_gadget/aio buffer may be left with stale data.

Future `EndpointSender::send_async` will then wait forever on a completion that never arrives.